### PR TITLE
Add CSS support for old versions of IE

### DIFF
--- a/app/assets/stylesheets/application-ie6.scss
+++ b/app/assets/stylesheets/application-ie6.scss
@@ -1,0 +1,7 @@
+// BASE STYLESHEET FOR IE 6 COMPILER
+
+$is-ie: true;
+$ie-version: 6;
+$mobile-ie6: false;
+
+@import "application.scss";

--- a/app/assets/stylesheets/application-ie7.scss
+++ b/app/assets/stylesheets/application-ie7.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 7 COMPILER
+
+$is-ie: true;
+$ie-version: 7;
+
+@import "application.scss";

--- a/app/assets/stylesheets/application-ie8.scss
+++ b/app/assets/stylesheets/application-ie8.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 8 COMPILER
+
+$is-ie: true;
+$ie-version: 8;
+
+@import "application.scss";

--- a/app/assets/stylesheets/calculators/child_benefit.scss
+++ b/app/assets/stylesheets/calculators/child_benefit.scss
@@ -50,7 +50,14 @@ select {
 
 details.help-panel {
   position: relative;
-  margin-top: 3.4em;
+
+  @include media(mobile) {
+    margin-top:4.8em;
+  }
+
+  @include media(desktop) {
+    margin-top: 3.4em;
+  }
 
   p,
   fieldset {
@@ -67,7 +74,14 @@ details.help-panel {
   }
   summary {
     position: absolute;
-    top: -2em;
+
+    @include media(mobile) {
+      top: -3.4em;
+    }
+
+    @include media(desktop) {
+      top: -2em;
+    }
   }
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <title><%= yield :title %> - GOV.UK</title>
-    <%= stylesheet_link_tag "application.css" %>
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application.css" %><!--<![endif]-->
+    <!--[if IE 6]><%= stylesheet_link_tag "application-ie6.css" %><![endif]-->
+    <!--[if IE 7]><%= stylesheet_link_tag "application-ie7.css" %><![endif]-->
+    <!--[if IE 8]><%= stylesheet_link_tag "application-ie8.css" %><![endif]-->
     <%= javascript_include_tag "application" %>
     <%= yield :head %>
   </head>


### PR DESCRIPTION
Application-specific CSS was missing stylesheets for older versions of IE.

This includes a fix for some spacing issues on mobile.
