### PR TITLE
Add application-ie*.css to precompiled stylesheets

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -65,6 +65,9 @@ module Calculators
 
     config.assets.precompile += %w(
       application.css
+      application-ie6.css
+      application-ie7.css
+      application-ie8.css
     )
 
     # Version of your assets, change this if you want to expire all your assets


### PR DESCRIPTION
Stops the app from falling over in non-development environments
