### PR TITLE
Set tabindex on the Results heading when results are present

### DIFF
--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -91,10 +91,10 @@
 
           <%= submit_tag "Calculate", :name => "results", :class => "button" %>
         <% end %>
-    
+
     <% if can_haz_results? -%>
     <div class="results">
-      <h2 id="results">Results</h2>
+      <h2 id="results" tabindex="0">Results</h2>
       <%= render "results" %>
     </div><!-- end .inner -->
     <% end -%>


### PR DESCRIPTION
Léonie advised that we use a tabindex to make sure the focus is set on the results area for screen readers when we have results.
