### PR TITLE
accessibility fixes for headings and form fields

### DIFF
--- a/app/assets/stylesheets/calculators/child_benefit.scss
+++ b/app/assets/stylesheets/calculators/child_benefit.scss
@@ -39,6 +39,7 @@ form.calculator,
 form.calculator {
   width: 75%;
   padding: 0 2em 1em 2em;
+  margin-bottom: 3em;
 
   h2 {
     margin: 2em 0 0.8em 0;
@@ -234,7 +235,7 @@ details.help-panel {
   .js-enabled & {
     display: none;
   }
-} 
+}  s
 
 #results .button {
   @include core-16;

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -64,7 +64,7 @@
               <li>use your partner’s income if it’s higher than yours</li>
               <li>you may get some of this information from your P60, P11D, employer or tax adviser</li>
             </ul>
-            <fieldset id="adjusted_net_income_calculator">
+            <div id="adjusted_net_income_calculator">
             <%= label_tag "gross_income", "Salary before tax" %>
             <%= money_input "gross_income", @adjusted_net_income_calculator.gross_income %>
             <%= label_tag "other_income", "Other employment income - eg self employment, taxable benefits (like a company car or medical insurance), company dividends, bonuses" %>
@@ -87,6 +87,7 @@
             <%= money_input "gift_aid_donations", @adjusted_net_income_calculator.gift_aid_donations %>
             <%= label_tag "outgoing_pension_contributions", "Pension contributions not paid from your salary" %>
             <%= money_input "outgoing_pension_contributions", @adjusted_net_income_calculator.outgoing_pension_contributions %>
+          </div>
           </fieldset>
 
           <%= submit_tag "Calculate", :name => "results", :class => "button" %>


### PR DESCRIPTION
Deleted fieldset in question 4 and replaced with a div so the fieldset/legend pairing makes the screen reader announce the legend text before the label of the first field.
