### PR TITLE
Add redirects for old smart_answer URLs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Calculators::Application.routes.draw do
     routes.get "/child-benefit-tax-calculator" => "child_benefit_tax#landing"
     routes.get "/child-benefit-tax-calculator/main" => "child_benefit_tax#main"
     routes.get "/child-benefit-tax-calculator/process_form" => "child_benefit_tax#process_form"
+    routes.get "/child-benefit-tax-calculator/y(/*responses)" => redirect("/child-benefit-tax-calculator/main")
   end
 end

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -563,4 +563,15 @@ feature "Child Benefit Tax Calculator" do
       end
     end
   end
+
+  it "should redirect requests for the old smart-answer" do
+    visit "/child-benefit-tax-calculator/y"
+    i_should_be_on "/child-benefit-tax-calculator/main"
+
+    visit "/child-benefit-tax-calculator/y/income_work_out/2012-13"
+    i_should_be_on "/child-benefit-tax-calculator/main"
+
+    visit "/child-benefit-tax-calculator/y/income_work_out/2012-13.json"
+    i_should_be_on "/child-benefit-tax-calculator/main"
+  end
 end

--- a/spec/support/path_helpers.rb
+++ b/spec/support/path_helpers.rb
@@ -1,0 +1,14 @@
+module PathHelpers
+
+  # Takes a URL path (with optional query string), and asserts that it matches the current URL.
+  def i_should_be_on(path_with_query, options = {})
+    expected = URI.parse(path_with_query)
+    current = URI.parse(current_url)
+    expect(current.path).to eq(expected.path)
+    unless options[:ignore_query]
+      expect(Rack::Utils.parse_query(current.query)).to eq(Rack::Utils.parse_query(expected.query))
+    end
+  end
+end
+
+RSpec.configuration.include PathHelpers, :type => :feature


### PR DESCRIPTION
This will redirect people who hit URLs corresponding to the smartanswer that this replaces to the start of the calculation.
