### PR TITLE
Remove redundant 'Skip to related" link

### DIFF
--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -2,11 +2,10 @@
 <% content_for :body_classes, "full-width" %>
 
 <main id="content" role="main" class="group calculator-page">
-  <header class="page-header group full-width">
-    <div class="full-width">
-    <h1><span>Quick answer</span> Child Benefit tax calculator</h1>
+  <header class="page-header group">
+    <div>
+      <h1><span>Quick answer</span> Child Benefit tax calculator</h1>
     </div>
-    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
   </header>
   <article>
     <%= form_tag("process_form", :method => :get, :id => "child_benefit_tax_calculator", :class => "calculator") do %>


### PR DESCRIPTION
There are is no related box on the calculation page, so this link links
no-where.

Also tidied up the header markup and removed unnecessary full-width
classes.
