### PR TITLE
Fix Child Benefit tax calculator bug(s).

### DIFF
--- a/app/models/starting_child.rb
+++ b/app/models/starting_child.rb
@@ -29,7 +29,7 @@ class StartingChild
 
   def next_monday_for_date(date)
     return nil if date.nil?
-    date.advance(:days => 8 - date.wday)
+    ChildBenefitTaxCalculator.new.monday_on_or_after(date)
   end
 
   def valid_dates

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -128,8 +128,8 @@ describe ChildBenefitTaxCalculator do
         :children_count => "1",
         :starting_children => {
           "0" => {
-            :start => { :year => "2012", :month => "02", :day => "01" },
-            :stop => { :year => "2014", :month => "05", :day => "01" }
+            :start => { :year => "2013", :month => "04", :day => "06" },
+            :stop => { :year => "2014", :month => "04", :day => "05" }
           }
         }
       }).benefits_claimed_amount.round(2).should == 1055.6
@@ -462,8 +462,8 @@ describe ChildBenefitTaxCalculator do
           },
           :year => "2013"
         })
-        # starting child for 5 weeks
-        calc.tax_estimate.round(1).should == 101
+        # starting child for 6 weeks
+        calc.tax_estimate.round(1).should == 121
       end
     end # tax year 2013-14
   end # starting & stopping children
@@ -487,6 +487,28 @@ describe ChildBenefitTaxCalculator do
           :stop => {:day => '23', :month => '03', :year => '2013'}
         }
       }}).benefits_claimed_amount.round(2).should == 411.30
+
+      ChildBenefitTaxCalculator.new({:year => "2012", :children_count => 2, :starting_children => {
+        "0" => {
+          :start => {:day => '06', :month => '01', :year => '2013'},
+          :stop => {:day => '06', :month => '04', :year => '2013'}
+        },
+        "1" => {
+          :start => {:day => '06', :month => '01', :year => '2013'},
+          :stop => {:day => '15', :month => '02', :year => '2013'}
+        }
+      }}).benefits_claimed_amount.round(2).should == 344.3 
+
+      ChildBenefitTaxCalculator.new({:year => "2012", :children_count => 2, :starting_children => {
+        "0" => {
+          :start => {:day => '06', :month => '01', :year => '2013'},
+          :stop => {:day => '06', :month => '04', :year => '2013'}
+        },
+        "1" => {
+          :start => {:day => '06', :month => '01', :year => '2013'},
+          :stop => {:day => '06', :month => '04', :year => '2013'}
+        }
+      }}).benefits_claimed_amount.round(2).should == 438.10
 
       calc = ChildBenefitTaxCalculator.new({
         :adjusted_net_income => "£65,000", :year => "2012", :children_count => 3, :starting_children => {

--- a/spec/models/starting_child_spec.rb
+++ b/spec/models/starting_child_spec.rb
@@ -52,13 +52,16 @@ describe StartingChild do
 
     it "should return the next Monday for the provided start date" do
       child = StartingChild.new(:start => {:year => "2012", :month => "01", :day => "01"})
-      child.adjusted_start_date.should ==  Date.parse("9 January 2012")
+      child.adjusted_start_date.should ==  Date.parse("2 January 2012")
 
       child = StartingChild.new(:start => {:year => "2013", :month => "05", :day => "08"})
       child.adjusted_start_date.should == Date.parse("13 May 2013")
 
       child = StartingChild.new(:start => {:year => "2013", :month => "08", :day => "13"})
       child.adjusted_start_date.should == Date.parse("19 August 2013")
+
+      child = StartingChild.new(:start => {:year => "2013", :month => "01", :day => "06"})
+      child.adjusted_start_date.should == Date.parse("7 January 2013")
     end
 
     it "should not blow up with a nil start date" do


### PR DESCRIPTION
Bugfix for problem mentioned in [this zendesk ticket](https://govuk.zendesk.com/agent/#/tickets/325313)
Fix the 'monday on or after' bug.
Add exceptions for child start dates in specific tax years.
