### PR TITLE
Adding gem to strip Client-IP headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'sass-rails', '3.2.5'
 
 gem 'logstasher', '0.4.8'
 gem 'airbrake', '3.1.15'
+gem 'rack_strip_client_ip', '0.0.1'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rack_strip_client_ip (0.0.1)
     rails (3.2.17)
       actionmailer (= 3.2.17)
       actionpack (= 3.2.17)
@@ -181,6 +182,7 @@ DEPENDENCIES
   logstasher (= 0.4.8)
   plek (= 1.3.1)
   poltergeist (= 1.3.0)
+  rack_strip_client_ip (= 0.0.1)
   rails (= 3.2.17)
   rspec-rails (= 2.13.2)
   sass-rails (= 3.2.5)


### PR DESCRIPTION
We've seen several instances of IpSpoofAttackError in Errbit recently, @alext's rack_strip_client_ip gem will hush these. 
Detailed explanation here - alphagov/whitehall#810. 
