### PR TITLE
Check SASS compiles as part of Jenkins test runner

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,8 +2,11 @@
 set -e
 
 export RAILS_ENV=test
+export GOVUK_APP_DOMAIN=dev.gov.uk
 
 git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 
 bundle exec rake ci:setup:rspec default
+
+bundle exec rake assets:precompile


### PR DESCRIPTION
- Running asset precompile will catch SASS syntactic/reference errors earlier.
