### PR TITLE
Remove gemfury source from Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
 gem 'rails', '3.2.17'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
     PriorityQueue (0.1.2)
     actionmailer (3.2.17)


### PR DESCRIPTION
We don't use any gems hosted on gemfury any more.
