### PR TITLE
Revert frontend toolkit upgrade, back to 0.20.0 (from 1.6.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
 gem 'rails', '3.2.17'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
     PriorityQueue (0.1.2)
     actionmailer (3.2.17)


### PR DESCRIPTION
This broke some tests depending on assets in older versions of the toolkit when https://github.com/alphagov/calculators/pull/96/ was merged. It wasn't spotted due to the lack of branch builds (i've run tests locally and they pass now).

This fixes the tests so calculators can be deployed.

A better fix will be to fix the tests, but that will require working out what assets are relied on, and possibly refactoring the design to remove the missing icons. That isn't straight forward, but i'll write up a tech debt story somewhere for it.

This reverts commit b35fd48a180ddacfdce30aa0d62c7d8695f23437.
and fd60b740bb2af00aca0d3988f1f336ed92bb2d03
