### PR TITLE
Add branch build script

### DIFF
--- a/jenkins_branches.sh
+++ b/jenkins_branches.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+VENV_PATH="${HOME}/venv/${JOB_NAME}"
+
+[ -x ${VENV_PATH}/bin/pip ] || virtualenv ${VENV_PATH}
+. ${VENV_PATH}/bin/activate
+
+pip install -q ghtools
+
+REPO="alphagov/calculators"
+gh-status "$REPO" "$GIT_COMMIT" pending -d "\"Build #${BUILD_NUMBER} is running on Jenkins\"" -u "$BUILD_URL" >/dev/null
+
+if ./jenkins.sh; then
+  gh-status "$REPO" "$GIT_COMMIT" success -d "\"Build #${BUILD_NUMBER} succeeded on Jenkins\"" -u "$BUILD_URL" >/dev/null
+  exit 0
+else
+  gh-status "$REPO" "$GIT_COMMIT" failure -d "\"Build #${BUILD_NUMBER} failed on Jenkins\"" -u "$BUILD_URL" >/dev/null
+  exit 1
+fi


### PR DESCRIPTION
Webhook + CI setup already, so this should have a test pass/fail below.

We were missing branch builds, which meant we missed failing tests like https://github.com/alphagov/calculators/pull/98
