### PR TITLE
Fix broken JS tests by updating PhantomJS SSL options

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,4 +2,9 @@ require 'capybara/rails'
 require 'capybara/rspec'
 
 require 'capybara/poltergeist'
+
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, { phantomjs_options: ['--ssl-protocol=TLSv1'] })
+end
+
 Capybara.javascript_driver = :poltergeist


### PR DESCRIPTION
phantomjs defaults to using SSLv3, which has now been disabled
everywhere.  The protocol used can be changed with an option:

> --ssl-protocol=<val>                 Sets the SSL protocol
>   (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')

This PR makes poltergeist and the  task set this option when invoking phantomjs.

Same as https://github.com/alphagov/frontend/pull/684.
