### PR TITLE
Fix broken tests by upgrading Slimmer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'unicorn', '4.6.2'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '3.25.0'
+  gem 'slimmer', '4.2.0'
 end
 gem 'plek', '1.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
+  remote: https://gem.fury.io/govuk/
   specs:
     PriorityQueue (0.1.2)
     actionmailer (3.2.17)
@@ -79,7 +79,7 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.25.1)
     multi_json (1.8.4)
-    nokogiri (1.5.9)
+    nokogiri (1.5.11)
     null_logger (0.0.1)
     parser (2.1.9)
       ast (>= 1.1, < 3.0)
@@ -150,7 +150,7 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (3.25.0)
+    slimmer (4.2.0)
       json
       lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
@@ -202,7 +202,7 @@ DEPENDENCIES
   rubocop
   sass-rails (= 3.2.5)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 3.25.0)
+  slimmer (= 4.2.0)
   timecop (= 0.6.2.2)
   uglifier (>= 1.0.3)
   unicorn (= 4.6.2)


### PR DESCRIPTION
Older versions of slimmer used a different host for assets
during tests. That host now has an SSL error and was breaking
test.
