### PR TITLE
Update for new static layout

### DIFF
--- a/app/assets/stylesheets/calculators/child_benefit.scss
+++ b/app/assets/stylesheets/calculators/child_benefit.scss
@@ -42,7 +42,7 @@ form.calculator,
 
 form.calculator {
   width: 75%;
-  padding: 0 2em 1em 2em;
+  padding: 0 0 1em;
 
   h2 {
     margin: 2em 0 0.8em 0;
@@ -163,7 +163,7 @@ form.calculator {
     text-decoration: underline;
     @include box-shadow(none);
     border: none;
-    overflow: visible; 
+    overflow: visible;
 
     &:hover,
     &:focus{
@@ -227,7 +227,7 @@ details.help-panel {
   .js-enabled & {
     display: none;
   }
-} 
+}
 
 #results .button {
   @include core-16;

--- a/app/views/child_benefit_tax/landing.html.erb
+++ b/app/views/child_benefit_tax/landing.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "Child Benefit tax calculator" %>
 <% content_for :wrapper_classes, "answer" %>
 
+<div class="grid-row">
 <main id="content" role="main" class="group">
   <header class="page-header group">
     <div>
@@ -39,3 +40,4 @@
 </main>
 
 <div id="related-items"></div>
+</div>

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -58,6 +58,7 @@ feature "Child Benefit Tax Calculator" do
   end
 
   it "should disallow dates with too many days for the selected month", js: true  do
+    Timecop.travel "2014-09-01"
     visit "/child-benefit-tax-calculator"
     click_on "Start now"
 
@@ -87,6 +88,7 @@ feature "Child Benefit Tax Calculator" do
   end
 
   it "should show error if no children are present in the selected tax year" do
+    Timecop.travel "2014-09-01"
     visit "/child-benefit-tax-calculator"
     click_on "Start now"
 


### PR DESCRIPTION
Static is now using floats for the main content. Update this app to be
ready for those changes.

Add grid-row element to wrap the related items on the landing page. This
will let the two columns remain.

Remove some now extra padding on the side of elements.

The matching pull request in static: https://github.com/alphagov/static/pull/530