### PR TITLE
[Don't merge other branches to master before this is merged] Child Benefit Tax Calculator for 2015/2016 fiscal year

### DIFF
--- a/app/models/child_benefit_rates.rb
+++ b/app/models/child_benefit_rates.rb
@@ -7,6 +7,7 @@ class ChildBenefitRates
     2012 => [20.3, 13.4],
     2013 => [20.3, 13.4],
     2014 => [20.5, 13.55],
+    2015 => [20.7, 13.7],
   }
 
   def initialize(year)

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -13,6 +13,7 @@ class ChildBenefitTaxCalculator
     "2012" => [Date.parse("2012-04-06"), Date.parse("2013-04-05")],
     "2013" => [Date.parse("2013-04-06"), Date.parse("2014-04-05")],
     "2014" => [Date.parse("2014-04-06"), Date.parse("2015-04-05")],
+    "2015" => [Date.parse("2015-04-06"), Date.parse("2016-04-05")],
   }
 
   validate :valid_child_dates

--- a/spec/controllers/child_benefit_tax_controller_spec.rb
+++ b/spec/controllers/child_benefit_tax_controller_spec.rb
@@ -5,17 +5,17 @@ describe ChildBenefitTaxController do
   describe "slimmer headers" do
     context "when the artefact exists" do
       before :each do
-	@artefact_data = artefact_for_slug('child-benefit-tax-calculator')
+        @artefact_data = artefact_for_slug('child-benefit-tax-calculator')
         content_api_has_an_artefact("child-benefit-tax-calculator", @artefact_data)
       end
 
       it "should populate slimmer header with the child benefit tax calculator artefact" do
-	get 'main'
+        get 'main'
         @response.headers["X-Slimmer-Artefact"].should == JSON.dump(@artefact_data)
       end
 
       it "should set the artefact format in the slimmer headers" do
-	get 'main'
+        get 'main'
         @response.headers["X-Slimmer-Format"].should == "calculator"
       end
     end
@@ -26,7 +26,7 @@ describe ChildBenefitTaxController do
       end
 
       it "should return success" do
-	get 'main'
+        get 'main'
         response.should be_success
       end
     end

--- a/spec/models/child_benefit_rates_spec.rb
+++ b/spec/models/child_benefit_rates_spec.rb
@@ -51,4 +51,16 @@ describe ChildBenefitRates do
 
   end
 
+  describe "return correct rates for 2015 year passed in" do
+    before(:each) do
+      @calc = ChildBenefitRates.new(2015)
+    end
+
+    it "should return correct rates" do
+      @calc.first_child_rate.should == 20.7
+      @calc.additional_child_rate.should == 13.7
+    end
+
+  end
+
 end

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -674,5 +674,73 @@ describe ChildBenefitTaxCalculator do
         calc.benefits_claimed_amount.round(2).should == 635.5
       end
     end
+
+    describe "tests for 2015 rates" do
+      it "should calculate 3 children already in the household for all of 2015/16" do
+        ChildBenefitTaxCalculator.new(
+          year: "2015",
+          children_count: 3,
+          starting_children: {
+            "0" => {
+              start: {day: "06", month: "04", year: "2015"},
+              stop: {day: "", month: "", year: ""},
+            },
+            "1" => {
+              start: {day: "06", month: "04", year: "2015"},
+              stop: {day: "", month: "", year: ""},
+            },
+            "2" => {
+              start: {day: "06", month: "04", year: "2015"},
+              stop: {day: "", month: "", year: ""},
+            },
+         },
+       ).benefits_claimed_amount.round(2).should == 2501.2
+      end
+
+      it "should give the total amount of benefits received for a full tax year 2015" do
+        ChildBenefitTaxCalculator.new(
+          year: "2015",
+          children_count: "1",
+          starting_children: {
+            "0" => {
+              start: { year: "2015", month: "04", day: "06" },
+              stop: { year: "2016", month: "04", day: "05" },
+            },
+          },
+        ).benefits_claimed_amount.round(2).should == 1076.4
+      end
+
+      it "should give total amount of benefits one child full year one child half a year" do
+        ChildBenefitTaxCalculator.new(
+          year: "2015",
+          children_count: 2,
+          starting_children: {
+            "0" => {
+              start: {day: "06", month: "04", year: "2015"},
+              stop: {day: "", month: "", year: ""},
+            },
+            "1" => {
+              start: {day: "06", month: "04", year: "2015"},
+              stop: {day: "06", month: "11", year: "2016"},
+            },
+          },
+        ).benefits_claimed_amount.round(2).should == 1788.8
+      end
+
+      it "should give total amount of benefits for one child for half a year" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2015",
+          children_count: 1,
+          starting_children: {
+            "0" => {
+              start: {day: "06", month: "04", year: "2015"},
+              stop: {day: "06", month: "11", year: "2015"},
+            },
+          },
+        )
+        calc.benefits_claimed_amount.round(2).should == 621.0
+      end
+    end
   end
+
 end


### PR DESCRIPTION
The logic is not changing, the values are changing as follows:

Child Benefit (eldest child) increases to £20.70
Child Benefit (subsequent children) increases to £13.70

Bonus: replaces random tabs with spaces.

We need to get this branch on preview so that they have a couple of weeks to test the changes. 

### Before merging

- [x] Wait for the stakeholders to manually test the changes on preview and give us a thumbs up