### PR TITLE
Stop using deprecated RSpec formatters in CI

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -7,6 +7,6 @@ export GOVUK_APP_DOMAIN=dev.gov.uk
 git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 
-bundle exec rake ci:setup:rspec default
+bundle exec rake
 
 bundle exec rake assets:precompile


### PR DESCRIPTION
After upgrading to Rails 4 we started seeing:

```
Deprecation Warnings:

The CI::Reporter::RSpec formatter uses the deprecated formatter interface not supported directly by RSpec 3.  To continue to use this formatter you must install the `rspec-legacy_formatters` gem, which provides support for legacy formatters or upgrade the formatter to a compatible version.  Formatter added at: /home/jenkins/bundles/govuk_calculators/ruby/2.1.0/gems/rspec-core-3.2.3/exe/rspec:4:in `<main>'
```

I've changed it to use the default `bundle exec rake`. I can't see a big difference in the output and the deprecation warning is gone. Is there any specific format we want to use or is the default fine?