### PR TITLE
Bump slimmer for rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'unicorn', '4.6.2'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '8.1.0'
+  gem 'slimmer', '8.2.1'
 end
 gem 'plek', '1.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.1.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -231,7 +231,7 @@ DEPENDENCIES
   rubocop
   sass-rails (= 5.0.3)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 8.1.0)
+  slimmer (= 8.2.1)
   timecop (= 0.6.2.2)
   uglifier (>= 2.7.1)
   unicorn (= 4.6.2)


### PR DESCRIPTION
So we can track which application renders which page in analytics update
slimmer for a new version which outputs the rendering application.

This contains both https://github.com/alphagov/slimmer/pull/126 and https://github.com/alphagov/slimmer/pull/128
