### PR TITLE
Disable session store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Calculators::Application.config.session_store :cookie_store, key: "_calculators_session"
+Calculators::Application.config.session_store :disabled
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/spec/initializers/session_store_spec.rb
+++ b/spec/initializers/session_store_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'session_store' do
+  it 'should be disabled' do
+    expect(Calculators::Application.config.session_store).to be_nil
+  end
+end


### PR DESCRIPTION
As requested by @tekin as a precautionary measure for all frontend apps.
Apparently the Varnish cache strips session cookies on the way in and out
anyway, but at some point such cookies will selectively be allowed through
in order to implement authentication.

c.f. https://github.com/alphagov/government-frontend/pull/48

I added a spec to make it clear that this was done intentionally.