### PR TITLE
Add meta description to Child Benefit Tax Calculator main page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 gem 'plek', '1.3.1'
 
 gem 'gds-api-adapters', '20.1.1'
-gem 'govuk_frontend_toolkit', '0.20.0', source: 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
+gem 'govuk_frontend_toolkit', '0.41.1'
 gem 'sass-rails', '5.0.3'
 
 gem 'logstasher', '0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
     PriorityQueue (0.1.2)
     actionmailer (4.2.2)
@@ -72,7 +71,7 @@ GEM
       rest-client (~> 1.8.0)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
-    govuk_frontend_toolkit (0.20.0)
+    govuk_frontend_toolkit (0.41.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     http-cookie (1.0.2)
@@ -234,7 +233,7 @@ DEPENDENCIES
   capybara (= 2.4.4)
   ci_reporter_rspec (~> 1.0.0)
   gds-api-adapters (= 20.1.1)
-  govuk_frontend_toolkit (= 0.20.0)!
+  govuk_frontend_toolkit (= 0.41.1)
   logstasher (= 0.4.8)
   plek (= 1.3.1)
   poltergeist (= 1.6.0)

--- a/app/assets/stylesheets/calculators/child_benefit.scss
+++ b/app/assets/stylesheets/calculators/child_benefit.scss
@@ -135,19 +135,19 @@ form.calculator {
   }
 
   #step-1 {
-    background-image: image-url("icon-step-1.png");
+    background-image: image-url("icon-steps/icon-step-1.png");
   }
 
   #step-2 {
-    background-image: image-url("icon-step-2.png");
+    background-image: image-url("icon-steps/icon-step-2.png");
   }
 
   #step-3 {
-    background-image: image-url("icon-step-3.png");
+    background-image: image-url("icon-steps/icon-step-3.png");
   }
 
   #step-4 {
-    background-image: image-url("icon-step-4.png");
+    background-image: image-url("icon-steps/icon-step-4.png");
   }
 
   .intro {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <!--[if IE 7]><%= stylesheet_link_tag "application-ie7.css" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8.css" %><![endif]-->
     <%= javascript_include_tag "application" %>
+    <meta name="description" content="Work out the Child Benefit you've received and your High Income Child Benefit tax charge">
     <%= yield :head %>
   </head>
 

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -8,6 +8,7 @@ feature "Child Benefit Tax Calculator" do
 
     within "head", visible: :all do
       expect(page).to have_selector("title", text: "Child Benefit tax calculator - GOV.UK", visible: :all)
+      expect(page).to have_selector(%Q{meta[name='description'][content="Work out the Child Benefit you've received and your High Income Child Benefit tax charge"]}, visible: false)
     end
 
     within "main#content" do


### PR DESCRIPTION
Part of improving search result snippets shown on external search engines.

The lack of a meta-description tag makes some search result snippets unhelpful, confusing or misleading. Ticket: https://trello.com/c/S6VUwRWQ/273-follow-up-add-meta-description-tag-to-custom-content-types