### PR TITLE
Bump slimmer and explicitly set slimmer template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'unicorn', '4.6.2'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '8.2.1'
+  gem 'slimmer', '9.0.0'
 end
 gem 'plek', '1.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -243,7 +243,7 @@ DEPENDENCIES
   rubocop
   sass-rails (= 5.0.3)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 8.2.1)
+  slimmer (= 9.0.0)
   timecop (= 0.6.2.2)
   uglifier (>= 2.7.1)
   unicorn (= 4.6.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   include GdsApi::Helpers
+  include Slimmer::Template
   include Slimmer::Headers
+
+  slimmer_template 'wrapper'
 
   protected
 


### PR DESCRIPTION
The latest version of slimmer changes the default template which gets
used. This would break some of the frontend to this application, so
explicitly ask for the right template.