### PR TITLE
Use v2 of publishing-api to write calculators to content store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ else
 end
 gem 'plek', '1.3.1'
 
-gem 'gds-api-adapters', '~> 24.4.0'
+gem 'gds-api-adapters', '~> 25.1'
 gem 'govuk_frontend_toolkit', '0.41.1'
 gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
 gem 'sass-rails', '5.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
-    gds-api-adapters (24.4.0)
+    gds-api-adapters (25.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -113,7 +113,7 @@ GEM
       websocket-driver (>= 0.2.0)
     powerpack (0.0.9)
     rack (1.6.4)
-    rack-cache (1.2)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -238,7 +238,7 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   capybara (= 2.4.4)
   ci_reporter_rspec (~> 1.0.0)
-  gds-api-adapters (~> 24.4.0)
+  gds-api-adapters (~> 25.1)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk_frontend_toolkit (= 0.41.1)
   logstasher (= 0.4.8)

--- a/app/presenters/calculator_content_item.rb
+++ b/app/presenters/calculator_content_item.rb
@@ -10,14 +10,23 @@ class CalculatorContentItem
     '/' + calculator.slug
   end
 
+  def content_id
+    calculator.content_id
+  end
+
+  def update_type
+    'minor'
+  end
+
   def payload
     {
       title: calculator.title,
-      content_id: calculator.content_id,
+      base_path: base_path,
+      content_id: content_id,
       format: 'placeholder_calculator',
       publishing_app: 'calculators',
       rendering_app: 'calculators',
-      update_type: 'minor',
+      update_type: update_type,
       locale: 'en',
       public_updated_at: Time.now.iso8601,
       routes: [

--- a/app/services/calculator_publisher.rb
+++ b/app/services/calculator_publisher.rb
@@ -4,7 +4,8 @@ class CalculatorPublisher
   end
 
   def publish
-    Services.publishing_api.put_content_item(rendered.base_path, rendered.payload)
+    Services.publishing_api.put_content(rendered.content_id, rendered.payload)
+    Services.publishing_api.publish(rendered.content_id, rendered.update_type)
   end
 
 private

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,7 +1,7 @@
-require 'gds_api/publishing_api'
+require 'gds_api/publishing_api_v2'
 
 module Services
   def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
+    @publishing_api ||= GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
   end
 end

--- a/spec/services/calculator_publisher_spec.rb
+++ b/spec/services/calculator_publisher_spec.rb
@@ -3,15 +3,11 @@ require 'spec_helper'
 describe CalculatorPublisher do
   describe '#publish' do
     it 'publishes the content item' do
-      allow(Services.publishing_api).to receive(:put_content_item)
+      expect(Services.publishing_api).to receive(:put_content).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', be_valid_against_schema('placeholder'))
+      expect(Services.publishing_api).to receive(:publish).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', 'minor')
       calendar = Calculator.all.first
 
       CalculatorPublisher.new(calendar).publish
-
-      expect(Services.publishing_api).to have_received(:put_content_item).with(
-        "/child-benefit-tax-calculator",
-        be_valid_against_schema('placeholder')
-      )
     end
   end
 end


### PR DESCRIPTION
All apps should now use v2 of the publishing api to write content to the content-store. This change converts calculators to use v2 of the api. The differences are:

 - put content_item is replaced by two methods - put_content, and publish
 - the content_id is used as the key, rather than the base path
 - the base path is included in the payload

Trello: https://trello.com/c/oo1qawYB/441-migrate-calculators-to-new-tagging-infrastructure