### PR TITLE
Remove children_in_taxable_period code and test.

### DIFF
--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -99,10 +99,6 @@ class ChildBenefitTaxCalculator
     (benefits_claimed_amount * (percent_tax_charge / 100.0)).floor
   end
 
-  def children_in_taxable_period?
-    @starting_children.select {|c| c.end_date.nil? || c.end_date > TAX_COMMENCEMENT_DATE }.any?
-  end
-
   private
 
   def process_starting_children(children)

--- a/app/views/child_benefit_tax/_results.html.erb
+++ b/app/views/child_benefit_tax/_results.html.erb
@@ -1,75 +1,66 @@
-<% if @calculator.children_in_taxable_period? %>
-  <%# child benefit received %>
+<div class="results_estimate">
+  <h3>Child Benefit received</h3>
+  <p class="numbers"><%= number_to_currency @calculator.benefits_claimed_amount, unit: "£", precision: 2 %></p>
+  <% if @calculator.tax_year == 2012 -%>
+    <p>Received between 7 January and 5 April 2013.</p>
+  <% end -%>
+  <p>Use this figure in your <%= tax_year_label(@calculator.tax_year) %> Self Assessment tax return (if you fill one in).</p>
+</div>
+<%# tax estimate %>
+<% if @calculator.adjusted_net_income -%>
   <div class="results_estimate">
-    <h3>Child Benefit received</h3>
-    <p class="numbers"><%= number_to_currency @calculator.benefits_claimed_amount, unit: "£", precision: 2 %></p>
-    <% if @calculator.tax_year == 2012 -%>
-      <p>Received between 7 January and 5 April 2013.</p>
-    <% end -%>
-    <p>Use this figure in your <%= tax_year_label(@calculator.tax_year) %> Self Assessment tax return (if you fill one in).</p>
-  </div>
-  <%# tax estimate %>
-  <% if @calculator.adjusted_net_income -%>
-    <div class="results_estimate">
-      <h3>Tax charge to pay</h3>
-
-      <% if @calculator.adjusted_net_income < 50100 -%>
-        <p class="numbers">£0.00</p>
-        <p>There is no tax charge if your income is below £50,099.</p>
-        <p>Your partner (if you have one) may have to pay the charge if their income is higher than yours.</p>
-        <p>Find out more about the <a href="<%= internal_url "/child-benefit-tax-charge" %>">tax charge</a>.</p>
-      <% else -%>
-        <p class="numbers"><%= number_to_currency @calculator.tax_estimate, unit: "£", precision: 2 %></p>
-
-        <% if @calculator.tax_year == 2012 -%>
-          <p>The tax charge only applies to the Child Benefit received between 7 January and 5 April 2013
-            and is based on your estimated adjusted net income of <%= number_to_currency @calculator.adjusted_net_income, unit: "£", precision: 2 %>.</p>
-        <% end -%>
-
-        <% if tax_year_incomplete? %>
-          <p>This is an estimate based on your adjusted net income of <%= number_to_currency @calculator.adjusted_net_income, unit: "£", precision: 2 %>
-            - your circumstances may change before the end of the tax year.</p>
-        <% end -%>
-
-        <h3>How and when to pay</h3>
-
-        <p>To pay the tax charge you must fill in a Self Assessment tax return each tax year. Follow these steps:</p>
-        <ol>
-          <li><a href="<%= internal_url "/register-for-self-assessment" %>">Register for Self Assessment</a> if you don’t already fill in a tax return - you should do this by <%= sa_register_deadline %>.</li>
-          <li>Fill in the tax return and include the amount of Child Benefit received for the tax year.</li>
-          <li>Send the tax return.</li>
-          <li>Pay the tax you owe.</li>
-        </ol>
-
-        <p>There are <a href="<%= internal_url "/self-assessment-tax-return-deadlines", 9 %>">deadlines</a> for sending the tax return and paying the tax.</p>
-
-        <div class="application-notice info-notice">
-          <p>The person with the highest income pays the tax charge, so use your partner’s income in the calculator if it’s higher than yours.</p>
-        </div>
-
-        <h3>Your Child Benefit</h3>
-        <p>You can choose to:</p>
-        <ul>
-          <li><a href="<%= internal_url "/child-benefit-tax-charge/stop-child-benefit" %>">stop getting Child Benefit</a> - you must pay any tax you owe</li>
-          <li>carry on getting Child Benefit - for each tax year you get it you must fill in a tax return and pay any tax you owe</li>
-        </ul>
-
-        <% if @calculator.tax_year == 2012 -%>
-          <p>Your result for the next tax year may be higher because the tax charge will apply to the whole tax year (and not just 7 January to 5 April 2013).</p>
-        <% end -%>
-
-        <p>Find out about <a href="<%= internal_url "/child-benefit-tax-charge" %>">stopping or carrying on Child Benefit</a>.</p>
-      <% end -%>
-    </div>
-  <% else %>
     <h3>Tax charge to pay</h3>
-    <p>To work out the tax charge, <a href="#adjusted_income">enter your income or your partner's</a> - whoever has the higher.</p>
-    <p>Find out more about the <a href="<%= internal_url "/child-benefit-tax-charge" %>">tax charge</a>.</p>
-  <% end %>
-<% else %>
-  <div class="results_estimate">
-    <p>Your Child Benefit stopped before 7 January 2013 so you aren’t affected by the tax charge.</p>
 
-    <p>Find out more about the <a href="<%= internal_url "/child-benefit-tax-charge" %>">tax charge</a>.</p>
+    <% if @calculator.adjusted_net_income < 50100 -%>
+      <p class="numbers">£0.00</p>
+      <p>There is no tax charge if your income is below £50,099.</p>
+      <p>Your partner (if you have one) may have to pay the charge if their income is higher than yours.</p>
+      <p>Find out more about the <a href="<%= internal_url "/child-benefit-tax-charge" %>">tax charge</a>.</p>
+    <% else -%>
+      <p class="numbers"><%= number_to_currency @calculator.tax_estimate, unit: "£", precision: 2 %></p>
+
+      <% if @calculator.tax_year == 2012 -%>
+        <p>The tax charge only applies to the Child Benefit received between 7 January and 5 April 2013
+          and is based on your estimated adjusted net income of <%= number_to_currency @calculator.adjusted_net_income, unit: "£", precision: 2 %>.</p>
+      <% end -%>
+
+      <% if tax_year_incomplete? %>
+        <p>This is an estimate based on your adjusted net income of <%= number_to_currency @calculator.adjusted_net_income, unit: "£", precision: 2 %>
+          - your circumstances may change before the end of the tax year.</p>
+      <% end -%>
+
+      <h3>How and when to pay</h3>
+
+      <p>To pay the tax charge you must fill in a Self Assessment tax return each tax year. Follow these steps:</p>
+      <ol>
+        <li><a href="<%= internal_url "/register-for-self-assessment" %>">Register for Self Assessment</a> if you don’t already fill in a tax return - you should do this by <%= sa_register_deadline %>.</li>
+        <li>Fill in the tax return and include the amount of Child Benefit received for the tax year.</li>
+        <li>Send the tax return.</li>
+        <li>Pay the tax you owe.</li>
+      </ol>
+
+      <p>There are <a href="<%= internal_url "/self-assessment-tax-return-deadlines", 9 %>">deadlines</a> for sending the tax return and paying the tax.</p>
+
+      <div class="application-notice info-notice">
+        <p>The person with the highest income pays the tax charge, so use your partner’s income in the calculator if it’s higher than yours.</p>
+      </div>
+
+      <h3>Your Child Benefit</h3>
+      <p>You can choose to:</p>
+      <ul>
+        <li><a href="<%= internal_url "/child-benefit-tax-charge/stop-child-benefit" %>">stop getting Child Benefit</a> - you must pay any tax you owe</li>
+        <li>carry on getting Child Benefit - for each tax year you get it you must fill in a tax return and pay any tax you owe</li>
+      </ul>
+
+      <% if @calculator.tax_year == 2012 -%>
+        <p>Your result for the next tax year may be higher because the tax charge will apply to the whole tax year (and not just 7 January to 5 April 2013).</p>
+      <% end -%>
+
+      <p>Find out about <a href="<%= internal_url "/child-benefit-tax-charge" %>">stopping or carrying on Child Benefit</a>.</p>
+    <% end -%>
   </div>
+<% else %>
+  <h3>Tax charge to pay</h3>
+  <p>To work out the tax charge, <a href="#adjusted_income">enter your income or your partner's</a> - whoever has the higher.</p>
+  <p>Find out more about the <a href="<%= internal_url "/child-benefit-tax-charge" %>">tax charge</a>.</p>
 <% end %>

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -481,32 +481,6 @@ feature "Child Benefit Tax Calculator" do
       end
 
     end # ANI below threshold
-
-    context "with all children stopping before 7th January 2013" do
-      it "should say there's nothing to pay when no ANI is entered" do
-        visit "/child-benefit-tax-calculator/main"
-
-        select "2012", from: "starting_children_0_start_year"
-        select "April", from: "starting_children_0_start_month"
-        select "5", from: "starting_children_0_start_day"
-
-        select "2013", from: "starting_children_0_stop_year"
-        select "January", from: "starting_children_0_stop_month"
-        select "5", from: "starting_children_0_stop_day"
-
-        choose "year_2012"
-        click_button "Calculate"
-
-        within ".results" do
-          within ".results_estimate" do
-            expect(page).to have_content "Your Child Benefit stopped before 7 January 2013 so you aren’t affected by the tax charge."
-            expect(page).to have_content "Find out more about the tax charge"
-          end
-
-          expect(page).not_to have_content("Use this figure in your 2012 to 2013 Self Assessment tax return")
-        end
-      end
-    end
   end
 
   describe "child benefit week runs Monday to Sunday" do

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -428,49 +428,6 @@ describe ChildBenefitTaxCalculator, :type => :model do
         #child from 01/02 to 01/03 => 5 weeks * 20.3
         expect(calc.tax_estimate.round(1)).to eq(81)
       end
-
-      it "has children in taxable period when children claimed for after 7th January" do
-        calc = ChildBenefitTaxCalculator.new(
-          children_count: 3,
-          starting_children: {
-            "0" => {
-              start: { year: "2011", month: "02", day: "01" },
-              stop: { year: "2013", month: "01", day: "15" },
-            },
-            "1" => {
-              start: { year: "2011", month: "02", day: "01" },
-              stop: { year: "2013", month: "05", day: "01" },
-            },
-            "2" => {
-              start: { year: "2011", month: "02", day: "01" },
-            },
-          },
-          year: "2012",
-        )
-        expect(calc.children_in_taxable_period?).to eq true
-      end
-
-      it "does not have any children in taxable period when stop dates all before 7th Jan 2013" do
-        calc = ChildBenefitTaxCalculator.new(
-          children_count: 3,
-          starting_children: {
-            "0" => {
-              start: { year: "2011", month: "02", day: "01" },
-              stop: { year: "2013", month: "01", day: "05" },
-            },
-            "1" => {
-              start: { year: "2011", month: "02", day: "01" },
-              stop: { year: "2012", month: "12", day: "01" },
-            },
-            "2" => {
-              start: { year: "2011", month: "02", day: "01" },
-              stop: { year: "2013", month: "01", day: "02" },
-            },
-          },
-          year: "2012",
-        )
-        expect(calc.children_in_taxable_period?).to eq false
-      end
     end # tax year 2012
 
     describe "tax year 2013" do


### PR DESCRIPTION
Since the tax charge was introduced in 2013, it is no longer possible to enter details of children whose child benefit stopped before the charge started.

https://trello.com/c/Mux2Mkbv/251-a-test-in-the-calculators-app-is-broken