### PR TITLE
Gross up relief at source pension contributions.

### DIFF
--- a/app/models/adjusted_net_income_calculator.rb
+++ b/app/models/adjusted_net_income_calculator.rb
@@ -29,7 +29,7 @@ class AdjustedNetIncomeCalculator
   end
 
   def deductions
-    @pension_contributions_from_pay + grossed_up(@gift_aid_donations) +
+    grossed_up(@pension_contributions_from_pay) + grossed_up(@gift_aid_donations) +
       @retirement_annuities + @cycle_scheme + @childcare + grossed_up(@outgoing_pension_contributions)
   end
 

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -291,7 +291,7 @@ feature "Child Benefit Tax Calculator" do
         expect(page).to have_content "Child Benefit received £263.90"
         expect(page).to have_content "Tax charge to pay £263.00"
 
-        expect(page).to have_content("based on your estimated adjusted net income of £120,825.00")
+        expect(page).to have_content("based on your estimated adjusted net income of £120,325.00")
       end
     end
 
@@ -319,7 +319,7 @@ feature "Child Benefit Tax Calculator" do
       click_on "Calculate"
 
       within ".results" do
-        expect(page).to have_content("based on your estimated adjusted net income of £120,825.00")
+        expect(page).to have_content("based on your estimated adjusted net income of £120,325.00")
       end
 
       fill_in "Salary before tax", with: "£50,000"
@@ -327,8 +327,8 @@ feature "Child Benefit Tax Calculator" do
 
       within ".results" do
         expect(page).to have_content "Child Benefit received £263.90"
-        expect(page).to have_content "Tax charge to pay £21.00"
-        expect(page).to have_content("based on your estimated adjusted net income of £50,825.00")
+        expect(page).to have_content "Tax charge to pay £7.00"
+        expect(page).to have_content("based on your estimated adjusted net income of £50,325.00")
       end
     end
   end

--- a/spec/models/adjusted_net_income_calculator_spec.rb
+++ b/spec/models/adjusted_net_income_calculator_spec.rb
@@ -30,7 +30,7 @@ describe AdjustedNetIncomeCalculator, :type => :model do
       expect(calc.childcare).to eq(2000)
       expect(calc.outgoing_pension_contributions).to eq(2000)
 
-      expect(calc.calculate_adjusted_net_income).to eq(61875)
+      expect(calc.calculate_adjusted_net_income).to eq(61625)
     end
   end
 

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -202,7 +202,7 @@ describe ChildBenefitTaxCalculator, :type => :model do
         childcare: "£1500",
         year: "2012",
         children_count: 2,
-      ).adjusted_net_income).to eq(67450)
+      ).adjusted_net_income).to eq(66950)
     end
 
     it "should ignore the adjusted_net_income parameter when using the calculation form params" do
@@ -220,7 +220,7 @@ describe ChildBenefitTaxCalculator, :type => :model do
         childcare: "£1500",
         year: "2012",
         children_count: 2,
-      ).adjusted_net_income).to eq(67450)
+      ).adjusted_net_income).to eq(66950)
     end
   end
 


### PR DESCRIPTION
The Child Benefit tax calculator input field states "Pension contributions deducted from your pay (don't include contributions deducted before tax)".

This is asking for any "relief at source" contributions as explained at https://www.gov.uk/tax-on-your-private-pension/pension-tax-relief and asking you to ignore pre-tax deductions.

But as stated in https://www.gov.uk/guidance/adjusted-net-income about relief at source contributions:
> Step 3 - take off pension contributions
> If you made a contribution to a pension scheme where your pension provider has already given you tax relief at basic rate, take off the ‘grossed-up’ amount - what you paid plus the basic rate of tax.
>
> So, for every £1 of pension contribution you made, take £1.25 from your net income.

The calculator is not grossing up the pension contribution and therefore can give incorrect information if you have a relief at source pension.

The online self assessment calculator (ie. when it calculates what you owe for you) appears to be performing the correct calculation (its figures do not agree with this calculator).