### PR TITLE
Add 2016-2017 tax year

### DIFF
--- a/app/models/child_benefit_rates.rb
+++ b/app/models/child_benefit_rates.rb
@@ -7,6 +7,7 @@ class ChildBenefitRates
     2013 => [20.3, 13.4],
     2014 => [20.5, 13.55],
     2015 => [20.7, 13.7],
+    2016 => [20.7, 13.7],
   }
 
   def initialize(year)

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -14,6 +14,7 @@ class ChildBenefitTaxCalculator
     "2013" => [Date.parse("2013-04-06"), Date.parse("2014-04-05")],
     "2014" => [Date.parse("2014-04-06"), Date.parse("2015-04-05")],
     "2015" => [Date.parse("2015-04-06"), Date.parse("2016-04-05")],
+    "2016" => [Date.parse("2016-04-06"), Date.parse("2017-04-05")],
   }
 
   validate :valid_child_dates

--- a/spec/models/child_benefit_rates_spec.rb
+++ b/spec/models/child_benefit_rates_spec.rb
@@ -55,4 +55,15 @@ describe ChildBenefitRates, type: :model do
       expect(@calc.additional_child_rate).to eq(13.7)
     end
   end
+
+  describe "return correct rates for 2016 year passed in" do
+    before(:each) do
+      @calc = ChildBenefitRates.new(2016)
+    end
+
+    it "should return correct rates" do
+      expect(@calc.first_child_rate).to eq(20.7)
+      expect(@calc.additional_child_rate).to eq(13.7)
+    end
+  end
 end

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -698,5 +698,72 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(calc.benefits_claimed_amount.round(2)).to eq(621.0)
       end
     end
+
+    describe "tests for 2016 rates" do
+      it "should calculate 3 children already in the household for all of 2016/17" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2016",
+          children_count: 3,
+          starting_children: {
+            "0" => {
+              start: { day: "06", month: "04", year: "2016" },
+              stop: { day: "", month: "", year: "" },
+            },
+            "1" => {
+              start: { day: "06", month: "04", year: "2016" },
+              stop: { day: "", month: "", year: "" },
+            },
+            "2" => {
+              start: { day: "06", month: "04", year: "2016" },
+              stop: { day: "", month: "", year: "" },
+            },
+         },
+       ).benefits_claimed_amount.round(2)).to eq(2501.2)
+      end
+
+      it "should give the total amount of benefits received for a full tax year 2016" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2016",
+          children_count: "1",
+          starting_children: {
+            "0" => {
+              start: { year: "2016", month: "04", day: "06" },
+              stop: { year: "2017", month: "04", day: "05" },
+            },
+          },
+        ).benefits_claimed_amount.round(2)).to eq(1076.4)
+      end
+
+      it "should give total amount of benefits one child full year one child half a year" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2016",
+          children_count: 2,
+          starting_children: {
+            "0" => {
+              start: { day: "06", month: "04", year: "2016" },
+              stop: { day: "", month: "", year: "" },
+            },
+            "1" => {
+              start: { day: "06", month: "04", year: "2016" },
+              stop: { day: "06", month: "10", year: "2016" },
+            },
+          },
+        ).benefits_claimed_amount.round(2)).to eq(1432.6)
+      end
+
+      it "should give total amount of benefits for one child for half a year" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2016",
+          children_count: 1,
+          starting_children: {
+            "0" => {
+              start: { day: "06", month: "04", year: "2016" },
+              stop: { day: "06", month: "11", year: "2016" },
+            },
+          },
+        )
+        expect(calc.benefits_claimed_amount.round(2)).to eq(621.0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Trello story: https://trello.com/c/A937JJzE/65-child-benefit-tax-calculator

## Expected Changes
* [URL on GOV.UK](https://www.gov.uk/child-benefit-tax-calculator/main)
    * Add a radio button for the 2016-2017 tax year to question 3. Child benefit rates are the same in 2016 to 2017 as they were in 2015 to 2016 - so the calculations are the same for users following the 2016 to 2017 option.

### Before

![screen shot 2016-04-05 at 11 55 58](https://cloud.githubusercontent.com/assets/5793815/14279485/6506f618-fb25-11e5-917e-d93a43c49cb3.png)

### After

![screen shot 2016-04-05 at 11 57 02](https://cloud.githubusercontent.com/assets/5793815/14279522/89b4b8b0-fb25-11e5-9934-e6963d778ab0.png)
