### PR TITLE
Add empty `details` to content item payload sent to publishing api

### DIFF
--- a/app/presenters/calculator_content_item.rb
+++ b/app/presenters/calculator_content_item.rb
@@ -23,6 +23,7 @@ class CalculatorContentItem
       title: calculator.title,
       base_path: base_path,
       format: 'placeholder_calculator',
+      details: {},
       publishing_app: 'calculators',
       rendering_app: 'calculators',
       locale: 'en',


### PR DESCRIPTION
The govuk-content-schemas have changed since the last time this
application was updated. The govuk-content-schemas now expects all
content payloads pushed to it to contain a `details` item.

This problem also occurred in the smart-answers repo.
See PR: https://github.com/alphagov/smart-answers/pull/2539