### PR TITLE
Allow users to select a child benefit stop date in years up to 2013

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Calculators
 This is an application to contain custom-built calculators.  These will initially replace some smart-answers that have
 outgrown the framework.
 
+## Child benefit tax calculator
+Currently the only calculator in this application is the Child benefit tax calculator.
+
+This calculator reports how much child benefit tax you are entitled during a tax year.
+
+There is a cut-off date of 7 January 2013. This is the date [High Income Child Benefit Tax Charge](https://www.gov.uk/child-benefit-tax-charge/overview) came in effect.  
+This means that if the 2012 tax year is selected the calculator will only calculate the child benefit you are entitled to from 7 Jan 2013 to 5 Apr 2013, not for the entire tax year.
+
+
 ## Running the app
 
 ```

--- a/app/views/child_benefit_tax/_starting_child.html.erb
+++ b/app/views/child_benefit_tax/_starting_child.html.erb
@@ -15,5 +15,5 @@
   <% end %>
   <%= select_date (child ? child.end_date : nil), :prefix => "starting_children[#{index}][stop]",
     :prompt => {:day => "Day", :month => "Month", :year => "Year" }, :order => [:day, :month, :year],
-    :start_year => 2.years.ago(Date.today).year, :end_year => 10.years.since(Date.today).year %>
+    :start_year => 3.years.ago(Date.today).year, :end_year => 10.years.since(Date.today).year %>
 </div>

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -85,6 +85,15 @@ feature "Child Benefit Tax Calculator" do
     )
   end
 
+  it "should allow stop date to be three years in the past" do
+    Timecop.freeze('2014-04-04')
+    visit "/child-benefit-tax-calculator"
+    click_on "Start now"
+
+    expected_year_list = ("2011".."2024").to_a
+    expect(page).to have_select("starting_children_0_stop_year", options: expected_year_list.unshift("Year"))
+  end
+
   it "should show error if no children are present in the selected tax year" do
     Timecop.travel "2014-09-01"
     visit "/child-benefit-tax-calculator"


### PR DESCRIPTION
Trello Story: https://trello.com/c/dbyKP467/168-child-benefit-tax-calculator-change-stop-date-in-question-2-to-4-years-in-the-past

## Motivation
A user can calculate their Child Benefit tax back to 7Jan 2013 in tax year 2012/13, as a consequence the Stop date should also include 2013 in the drop down boxes. 
As the box is optional, if an end date isn't included, the calculator would calculate for a whole year, which isn't appropriate if the payments stopped during the year.

Dates are added to both selectors determining how many years to include (back and forward) starting from the current year.

Changed the stop year drop-down to include years up to four years ago.

## Factcheck

[Child benefit tax calculator](https://calculators-pr-136.herokuapp.com/child-benefit-tax-calculator/main)

## Expected Changes
[URL on GOV.UK](https://www.gov.uk/child-benefit-tax-calculator/main)
* Stop date should display years from 2013

![screen shot 2016-05-31 at 18 30 37](https://cloud.githubusercontent.com/assets/5793815/15684180/d9f23cf8-275d-11e6-8ff5-22cfbd69dfdf.png)

### Before

![screen shot 2016-05-31 at 18 31 33](https://cloud.githubusercontent.com/assets/5793815/15684217/04dfa126-275e-11e6-823c-8c4346e60133.png)

### After

![screen shot 2016-06-01 at 11 52 36](https://cloud.githubusercontent.com/assets/5793815/15707214/6376dfd8-27ef-11e6-9c65-406760f56a28.png)