### PR TITLE
Reorder questions two and three

### DIFF
--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -35,17 +35,8 @@
           <%= submit_tag "Update", :name => "children", :class => "button update-button" %>
         </fieldset>
 
-        <fieldset id="children">
-          <%= step(2, "Enter the Child Benefit start and stop dates:") %>
-          <ul>
-            <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
-            <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
-          </ul>
-          <%= render "starting_children" %>
-        </fieldset>
-
         <fieldset id="tax-year">
-          <%= step(3, "Choose a tax year:") %>
+          <%= step(2, "Choose a tax year:") %>
           <p>Tax years run from 6 April to 5 April the following year.</p>
           <div class="tax-year<% if @calculator.errors.has_key?(:tax_year) %> validation-error<% end %>">
             <% @calculator.errors[:tax_year].each do |message| %>
@@ -58,6 +49,15 @@
               </label>
             <% end -%>
           </div>
+        </fieldset>
+
+        <fieldset id="children">
+          <%= step(3, "Enter the Child Benefit start and stop dates:") %>
+          <ul>
+            <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
+            <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
+          </ul>
+          <%= render "starting_children" %>
         </fieldset>
 
         <fieldset id="adjusted_income">


### PR DESCRIPTION
Trello story: https://trello.com/c/hThMXpGx/170-child-benefit-tax-calculator-re-order-questions-2-and-3-swap-them-around

## Factcheck

[Child benefit tax calculator](https://calculators-pr-141.herokuapp.com/child-benefit-tax-calculator/main)

## Expected Changes

[URL on GOV.UK](https://www.gov.uk/child-benefit-tax-calculator/main)
* In preparation for the new Part year question, reorder questions two and three so that the users is asked to select the tax year they want to check before entering the child benefit start and end dates for their children.

### Before

![screen shot 2016-06-02 at 12 00 23](https://cloud.githubusercontent.com/assets/5793815/15742900/9da6e386-28b9-11e6-9c95-8d7823de0dcd.png)

### After

![screen shot 2016-06-02 at 12 06 06](https://cloud.githubusercontent.com/assets/5793815/15743012/6a313faa-28ba-11e6-98f7-be0e85ac46aa.png)
