### PR TITLE
Create a new Question 3 for Part Year Tax Claim

### DIFF
--- a/app/assets/javascripts/child-benefit-tax-calculator.js
+++ b/app/assets/javascripts/child-benefit-tax-calculator.js
@@ -1,4 +1,4 @@
-(function () {
+(function() {
   "use strict";
 
   var root = this,
@@ -7,17 +7,41 @@
 
   var calculator = {
     childrenCountInput: $("#children_count"),
-    childrenContainer: $("fieldset#children"),
-
-    setEventHandlers: function () {
-      calculator.childrenCountInput.on('change', calculator.updateChildrenFields);
+    childrenContainerTemplate: $("div#children-template"),
+    taxClaimContainer: $("fieldset#is-part-year-claim"),
+    taxClaimDurationInputs: $("input[id^='is_part_year_claim_']"),
+    childrenContainer: function() {
+      return $("div#children");
     },
-    updateChildrenFields: function () {
+    setEventHandlers: function() {
+      calculator.childrenCountInput.on('change', calculator.updateChildrenFields);
+      calculator.taxClaimDurationInputs.on('change', calculator.triggerChildrenFieldsEvent);
+      calculator.setUpForm();
+    },
+    setUpForm: function(){
+      var choosenTaxClaim = calculator.taxClaimDurationInputs.filter(":checked").val();
+      calculator.toggleChildrenFields(choosenTaxClaim);
+    },
+    triggerChildrenFieldsEvent: function(event){
+      calculator.toggleChildrenFields($(event.currentTarget).val());
+    },
+    toggleChildrenFields: function(choosen){
+      if (choosen == "yes") {
+        if (calculator.childrenContainer().length == 0) {
+          var childrenTag = calculator.childrenContainerTemplate.clone();
+          calculator.taxClaimContainer.append(childrenTag);
+          childrenTag.attr("id", "children").show();
+          calculator.updateChildrenFields();
+        }
+      } else {
+        calculator.childrenContainer().remove();
+      }
+    },
+    updateChildrenFields: function() {
       var numStartingChildren = calculator.childrenCountInput.val(),
-        childFields = calculator.childrenContainer.find('> div.child'),
+        childFields = calculator.childrenContainer().find("> div.child"),
         numChildFields = childFields.size(),
         numNewFields = numStartingChildren - numChildFields;
-
       if (numStartingChildren < 1 || numStartingChildren > 10) {
         return false;
       }
@@ -31,7 +55,7 @@
         }
       }
     },
-    appendChildField: function (index) {
+    appendChildField: function(index) {
       var newChild = calculator.childFieldToClone().clone();
 
       newChild.find('.child-number').text(index+1);
@@ -44,14 +68,14 @@
         $(this).attr('for', calculator.replaceIndex(index, $(this).attr('for')));
       });
 
-      newChild.appendTo(calculator.childrenContainer);
+      newChild.appendTo(calculator.childrenContainer());
     },
-    childFieldToClone: function () {
+    childFieldToClone: function() {
       // Always clone the first field so that we don't have to guess
       // the index (it will always be zero)
-      return calculator.childrenContainer.find("> div.child").first();
+      return calculator.childrenContainer().find("> div.child").first();
     },
-    replaceIndex: function (index, str) {
+    replaceIndex: function(index, str) {
       return str.replace("0", index);
     }
   };

--- a/app/assets/stylesheets/calculators/child_benefit.scss
+++ b/app/assets/stylesheets/calculators/child_benefit.scss
@@ -104,6 +104,7 @@ li {
   // scss-lint:disable IdSelector
   #children {
     margin-bottom: 0;
+    float: left;
 
     h3 {
       @include bold-19;

--- a/app/models/adjusted_net_income_calculator.rb
+++ b/app/models/adjusted_net_income_calculator.rb
@@ -2,7 +2,7 @@
 class AdjustedNetIncomeCalculator
   PARAM_KEYS = [:gross_income, :other_income, :pension_contributions_from_pay,
                 :retirement_annuities, :cycle_scheme, :childcare, :pensions, :property,
-                :non_employment_income, :gift_aid_donations, :outgoing_pension_contributions]
+                :non_employment_income, :gift_aid_donations, :outgoing_pension_contributions, :is_part_year_claim]
 
   def initialize(params)
     PARAM_KEYS.each do |key|

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -4,7 +4,7 @@ class ChildBenefitTaxCalculator
   include ActiveModel::Validations
 
   attr_reader :adjusted_net_income_calculator, :adjusted_net_income, :children_count,
-    :starting_children, :tax_year
+    :starting_children, :tax_year, :is_part_year_claim
 
   NET_INCOME_THRESHOLD = 50000
   TAX_COMMENCEMENT_DATE = Date.parse('7 Jan 2013')
@@ -18,6 +18,7 @@ class ChildBenefitTaxCalculator
   }
 
   validate :valid_child_dates
+  validates_presence_of :is_part_year_claim, message: "select part year tax claim"
   validates_inclusion_of :tax_year, in: TAX_YEARS.keys.map(&:to_i), message: "select a tax year"
   validate :tax_year_contains_at_least_one_child
 
@@ -25,6 +26,7 @@ class ChildBenefitTaxCalculator
     @adjusted_net_income_calculator = AdjustedNetIncomeCalculator.new(params)
     @adjusted_net_income = calculate_adjusted_net_income(params[:adjusted_net_income])
     @children_count = params[:children_count] ? params[:children_count].to_i : 1
+    @is_part_year_claim = params[:is_part_year_claim]
     @starting_children = process_starting_children(params[:starting_children])
     @tax_year = params[:year].to_i
   end
@@ -46,7 +48,11 @@ class ChildBenefitTaxCalculator
   end
 
   def has_errors?
-    errors.any? || starting_children.select { |c| c.errors.any? }.any?
+    errors.any? || starting_children_errors?
+  end
+
+  def starting_children_errors?
+    is_part_year_claim == 'yes' && starting_children.select { |c| c.errors.any? }.any?
   end
 
   def percent_tax_charge

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -51,13 +51,20 @@
           </div>
         </fieldset>
 
-        <fieldset id="children">
-          <%= step(3, "Enter the Child Benefit start and stop dates:") %>
-          <ul>
-            <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
-            <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
-          </ul>
-          <%= render "starting_children" %>
+        <fieldset id="is-part-year-claim">
+          <%= step(3, "Choose a tax claim duration:") %>
+          <p>Are you claiming for a part of the tax year for any of your children?</p>
+          <div class="is-part-year-claim<% if @calculator.errors.has_key?(:is_part_year_claim) %> validation-error<% end %>">
+            <% @calculator.errors[:is_part_year_claim].each do |message| %>
+              <p><%= message %></p>
+            <% end -%>
+            <% ["yes", "no"].each do |option| -%>
+              <label for="is_part_year_claim_<%= option %>" class="selectable">
+                <%= radio_button_tag "is_part_year_claim", option, (@calculator.is_part_year_claim == option) %>
+                <%= option.capitalize %>
+              </label>
+            <% end -%>
+          </div>
         </fieldset>
 
         <fieldset id="adjusted_income">
@@ -93,6 +100,14 @@
 
         <%= submit_tag "Calculate", :name => "results", :class => "button" %>
       <% end %>
+      <div id="children-template" style="display:none">
+        <h2>Enter the Child Benefit start and stop dates:</h2>
+        <ul>
+          <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
+          <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
+        </ul>
+        <%= render "starting_children" %>
+      </div>
 
       <% if can_haz_results? -%>
       <div class="results">

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "spec_helper"
 
-feature "Child Benefit Tax Calculator" do
+feature "Child Benefit Tax Calculator", js: true do
   specify "inspecting the landing page" do
     visit "/child-benefit-tax-calculator"
 
@@ -35,30 +35,87 @@ feature "Child Benefit Tax Calculator" do
     expect(page).to have_no_css(".results")
   end
 
-  it "should display validation errors" do
-    visit "/child-benefit-tax-calculator"
-    click_on "Start now"
-    click_on "Calculate"
-
-    within ".validation-summary" do
-      expect(page).to have_content("select a tax year")
-      expect(page).to have_content("enter the date Child Benefit started")
+  context "page errors" do
+    before :each do
+      visit "/child-benefit-tax-calculator"
+      click_on "Start now"
     end
 
-    within "#tax-year" do
-      expect(page).to have_css(".validation-error")
-      expect(page).to have_content("select a tax year")
+    context "when tax claim duration isn't selected" do
+      it "should display validation errors" do
+        click_on "Calculate"
+        within ".validation-summary" do
+          expect(page).to have_content("select a tax year")
+          expect(page).to have_content("enter the date Child Benefit started")
+        end
+
+        within "#tax-year" do
+          expect(page).to have_css(".validation-error")
+          expect(page).to have_content("select a tax year")
+        end
+
+        within "#is-part-year-claim" do
+          expect(page).to have_css(".validation-error")
+          expect(page).to have_no_css("#children")
+          expect(page).to have_content("select part year tax claim")
+        end
+      end
     end
-    within "#children" do
-      expect(page).to have_css(".validation-error")
-      expect(page).to have_content("enter the date Child Benefit started")
+
+    context "when NO is selected for tax claim duration" do
+      it "should display validation errors" do
+        choose "No"
+        click_on "Calculate"
+        within ".validation-summary" do
+          expect(page).to have_content("select a tax year")
+          expect(page).to have_content("enter the date Child Benefit started")
+        end
+
+        within "#tax-year" do
+          expect(page).to have_css(".validation-error")
+          expect(page).to have_content("select a tax year")
+        end
+
+        within "#is-part-year-claim" do
+          expect(page).to have_no_css(".validation-error")
+          expect(page).to have_no_css("#children")
+          expect(page).to have_no_content("select part year tax claim")
+        end
+      end
+    end
+
+    context "when YES is selected for tax claim duration" do
+      it "should display validation errors" do
+        choose "Yes"
+        click_on "Calculate"
+        within ".validation-summary" do
+          expect(page).to have_content("select a tax year")
+          expect(page).to have_content("enter the date Child Benefit started")
+        end
+
+        within "#tax-year" do
+          expect(page).to have_css(".validation-error")
+          expect(page).to have_content("select a tax year")
+        end
+
+        within "#is-part-year-claim" do
+          expect(page).to have_css(".validation-error")
+          expect(page).to have_no_content("select part year tax claim")
+
+          within "#children" do
+            expect(page).to have_css(".validation-error")
+            expect(page).to have_content("enter the date Child Benefit started")
+          end
+        end
+      end
     end
   end
 
-  it "should disallow dates with too many days for the selected month", js: true do
+  it "should disallow dates with too many days for the selected month" do
     Timecop.travel "2014-09-01"
     visit "/child-benefit-tax-calculator"
     click_on "Start now"
+    choose "Yes"
 
     select "2", from: "children_count"
 
@@ -89,6 +146,7 @@ feature "Child Benefit Tax Calculator" do
     Timecop.freeze('2014-04-04')
     visit "/child-benefit-tax-calculator"
     click_on "Start now"
+    choose "Yes"
 
     expected_year_list = ("2011".."2024").to_a
     expect(page).to have_select("starting_children_0_stop_year", options: expected_year_list.unshift("Year"))
@@ -98,6 +156,7 @@ feature "Child Benefit Tax Calculator" do
     Timecop.travel "2014-09-01"
     visit "/child-benefit-tax-calculator"
     click_on "Start now"
+    choose "Yes"
 
     select "1", from: "children_count"
     click_button "Update"
@@ -127,6 +186,7 @@ feature "Child Benefit Tax Calculator" do
     before(:each) do
       visit "/child-benefit-tax-calculator"
       click_on "Start now"
+      choose "Yes"
       select "2", from: "children_count"
       click_button "Update"
     end
@@ -172,7 +232,7 @@ feature "Child Benefit Tax Calculator" do
       expect(page).to have_no_css("#starting_children_1_start_day")
     end
 
-    it "should show the required number of date inputs without reloading the page", js: true do
+    it "should show the required number of date inputs without reloading the page" do
       expect(page).to have_select("children_count", selected: "2")
 
       expect(page).to have_css("#starting_children_0_start_year")
@@ -236,10 +296,12 @@ feature "Child Benefit Tax Calculator" do
       allow_any_instance_of(ChildBenefitTaxCalculator).to receive(:benefits_claimed_amount).and_return(500000)
       visit "/child-benefit-tax-calculator"
       click_on "Start now"
+      choose "Yes"
     end
 
     it "should give an estimated total of tax due related to income" do
       allow_any_instance_of(ChildBenefitTaxCalculator).to receive(:tax_estimate).and_return(500000)
+
       select "2011", from: "starting_children[0][start][year]"
       select "January", from: "starting_children[0][start][month]"
       select "1", from: "starting_children[0][start][day]"
@@ -271,8 +333,12 @@ feature "Child Benefit Tax Calculator" do
   end
 
   describe "calculating adjusted net income" do
+    before(:each) do
+      visit "/child-benefit-tax-calculator"
+      click_on "Start now"
+      choose "Yes"
+    end
     it "should use the adjusted net income calculator inputs" do
-      visit "/child-benefit-tax-calculator/main"
 
       select "2011", from: "starting_children[0][start][year]"
       select "January", from: "starting_children[0][start][month]"
@@ -303,8 +369,6 @@ feature "Child Benefit Tax Calculator" do
     end
 
     it "should update the adjusted_net_income when the calculator values are updated." do
-      visit "/child-benefit-tax-calculator/main"
-
       select "2011", from: "starting_children[0][start][year]"
       select "January", from: "starting_children[0][start][month]"
       select "1", from: "starting_children[0][start][day]"
@@ -341,10 +405,14 @@ feature "Child Benefit Tax Calculator" do
   end
 
   describe "displaying the results" do
+    before(:each) do
+      visit "/child-benefit-tax-calculator"
+      click_on "Start now"
+      choose "Yes"
+    end
+
     context "without the tax estimate" do
       before :each do
-        visit "/child-benefit-tax-calculator/main"
-
         select "2011", from: "starting_children_0_start_year"
         select "January", from: "starting_children_0_start_month"
         select "1", from: "starting_children_0_start_day"
@@ -385,8 +453,6 @@ feature "Child Benefit Tax Calculator" do
 
     context "with the tax estimate" do
       before :each do
-        visit "/child-benefit-tax-calculator/main"
-
         select "2011", from: "starting_children_0_start_year"
         select "January", from: "starting_children_0_start_month"
         select "1", from: "starting_children_0_start_day"
@@ -460,8 +526,6 @@ feature "Child Benefit Tax Calculator" do
 
     context "with an Adjusted Net Income below the threshold" do
       it "should say there's nothing to pay" do
-        visit "/child-benefit-tax-calculator/main"
-
         select "2011", from: "starting_children_0_start_year"
         select "January", from: "starting_children_0_start_month"
         select "1", from: "starting_children_0_start_day"
@@ -489,10 +553,14 @@ feature "Child Benefit Tax Calculator" do
   end
 
   describe "child benefit week runs Monday to Sunday" do
+    before(:each) do
+      visit "/child-benefit-tax-calculator"
+      click_on "Start now"
+      choose "Yes"
+    end
+
     context "tax year is 2012/2013" do
       specify "should have no child benefit when start date is 07/01/2013" do
-        visit "/child-benefit-tax-calculator/main"
-
         select "2013", from: "starting_children_0_start_year"
         select "January", from: "starting_children_0_start_month"
         select "7", from: "starting_children_0_start_day"
@@ -503,8 +571,6 @@ feature "Child Benefit Tax Calculator" do
       end
 
       specify "should have no child benefit when start date is 01/04/2013" do
-        visit "/child-benefit-tax-calculator/main"
-
         select "2013", from: "starting_children_0_start_year"
         select "April", from: "starting_children_0_start_month"
         select "1", from: "starting_children_0_start_day"
@@ -516,8 +582,6 @@ feature "Child Benefit Tax Calculator" do
       end
 
       specify "should have no child benefit when start date is 05/04/2013" do
-        visit "/child-benefit-tax-calculator/main"
-
         select "2013", from: "starting_children_0_start_year"
         select "April", from: "starting_children_0_start_month"
         select "5", from: "starting_children_0_start_day"
@@ -531,8 +595,6 @@ feature "Child Benefit Tax Calculator" do
 
     context "tax year is 2013/2014" do
       specify "should have no child benefit when start date is 31/03/2014" do
-        visit "/child-benefit-tax-calculator/main"
-
         select "2014", from: "starting_children_0_start_year"
         select "March", from: "starting_children_0_start_month"
         select "31", from: "starting_children_0_start_day"
@@ -544,8 +606,6 @@ feature "Child Benefit Tax Calculator" do
       end
 
       specify "should have no child benefit when start date is 01/04/2014" do
-        visit "/child-benefit-tax-calculator/main"
-
         select "2014", from: "starting_children_0_start_year"
         select "April", from: "starting_children_0_start_month"
         select "1", from: "starting_children_0_start_day"
@@ -557,8 +617,6 @@ feature "Child Benefit Tax Calculator" do
       end
 
       specify "should have no child benefit when start date is 05/04/2014" do
-        visit "/child-benefit-tax-calculator/main"
-
         select "2014", from: "starting_children_0_start_year"
         select "April", from: "starting_children_0_start_month"
         select "5", from: "starting_children_0_start_day"

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -15,6 +15,7 @@ describe ChildBenefitTaxCalculator, type: :model do
   it "is valid if given enough detail" do
     expect(ChildBenefitTaxCalculator.new(
       year: "2012", children_count: "1",
+      is_part_year_claim: "yes",
       starting_children: { "0" => { start: { year: "2011", month: "01", day: "01" } } },
     ).can_calculate?).to eq(true)
   end
@@ -26,7 +27,7 @@ describe ChildBenefitTaxCalculator, type: :model do
 
   describe "input validation" do
     before(:each) do
-      @calc = ChildBenefitTaxCalculator.new(children_count: "1")
+      @calc = ChildBenefitTaxCalculator.new(children_count: "1", is_part_year_claim: "no")
       @calc.valid?
     end
     it "should contain errors for year if none is given" do
@@ -50,6 +51,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc = ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -65,6 +67,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc = ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -80,6 +83,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc = ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "3",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -105,7 +109,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(@calc.errors.size).to eq(1)
       end
       it "should be true if any starting children have errors" do
-        calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1")
+        calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1", is_part_year_claim: "yes")
         calc.valid?
         expect(calc.errors).to be_empty
         #puts calc.starting_children.first.errors.full_messages
@@ -115,6 +119,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2012",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2012", month: "01", day: "07" } },
           },
@@ -135,7 +140,13 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(calc.errors).to be_empty
       end
       it "should not contain errors if tax claim duration is set to yes" do
-        calc = ChildBenefitTaxCalculator.new(children_count: "1", year: 2012, is_part_year_claim: "yes")
+        calc = ChildBenefitTaxCalculator.new(children_count: "1",
+            year: 2012,
+            is_part_year_claim: "yes",
+            starting_children: {
+              "0" => { start: { year: "2012", month: "01", day: "07" } },
+            }
+          )
         calc.valid?
         expect(calc.errors).to be_empty
       end
@@ -147,6 +158,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "02", day: "01" },
@@ -159,6 +171,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2013", month: "04", day: "06" },
@@ -171,6 +184,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -183,6 +197,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "2",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -204,6 +219,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         other_income: "0",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).adjusted_net_income).to eq(50099)
     end
 
@@ -221,6 +237,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         childcare: "£1500",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).adjusted_net_income).to eq(66950)
     end
 
@@ -239,6 +256,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         childcare: "£1500",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).adjusted_net_income).to eq(66950)
     end
   end
@@ -249,6 +267,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "50099",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(0.0)
     end
     it "should be 1.0 for an income of 50199" do
@@ -256,6 +275,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "50199",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(1.0)
     end
     it "should be 2.0 for an income of 50200" do
@@ -263,6 +283,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "50200",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(2.0)
     end
     it "should be 40.0 for an income of 54013" do
@@ -270,6 +291,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "54013",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(40.0)
     end
     it "should be 40.0 for an income of 54089" do
@@ -277,12 +299,14 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "54089",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(40.0)
     end
     it "should be 99.0 for an income of 59999" do
       expect(ChildBenefitTaxCalculator.new(
         adjusted_net_income: "59999",
         year: "2012",
+        is_part_year_claim: "no",
         children_count: 2,
       ).percent_tax_charge).to eq(99.0)
     end
@@ -291,6 +315,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "60000",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(100.0)
     end
     it "should be 100.0 for an income of 60001" do
@@ -298,6 +323,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "60001",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(100.0)
     end
   end
@@ -307,6 +333,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "should be true for incomes under the threshold" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "49999",
+          is_part_year_claim: "yes",
           children_count: 1,
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
@@ -317,6 +344,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "should be true for incomes over the threshold" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "50100",
+          is_part_year_claim: "yes",
           children_count: 1,
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
@@ -330,6 +358,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "calculates the correct amount owed for % charge of 100" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "60001",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -341,6 +370,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "59900",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -352,6 +382,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "54000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -365,6 +396,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "60001",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -376,6 +408,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "59900",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -387,6 +420,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "54000",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2011", month: "01", day: "01" },
@@ -406,6 +440,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "03", day: "01" },
@@ -421,6 +456,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2012", month: "05", day: "01" },
@@ -436,6 +472,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "02", day: "01" },
@@ -454,6 +491,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "02", day: "22" },
@@ -473,6 +511,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: 3,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
@@ -492,7 +531,9 @@ describe ChildBenefitTaxCalculator, type: :model do
     it "should calculate 3 children for 2012/2013 one child starting on 7 Jan 2013" do
       calc = ChildBenefitTaxCalculator.new(
         adjusted_net_income: "56000",
-        year: "2012", children_count: 3, starting_children: {
+        year: "2012", children_count: 3,
+        is_part_year_claim: "yes",
+        starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
             stop: { day: "05", month: "04", year: "2013" },
@@ -514,6 +555,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: 1,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "14", month: "01", year: "2013" },
@@ -527,6 +569,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "52000",
         year: "2013",
         children_count: 3,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -550,6 +593,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "53000",
         year: "2013",
         children_count: 3,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -573,6 +617,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "61000",
         year: "2013",
         children_count: 1,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "24", month: "06", year: "2013" },
@@ -589,6 +634,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 3,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -610,6 +656,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "04", day: "06" },
@@ -623,6 +670,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 2,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -640,6 +688,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -656,6 +705,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 3,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -677,6 +727,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2015", month: "04", day: "06" },
@@ -690,6 +741,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 2,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -707,6 +759,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -723,6 +776,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 3,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -744,6 +798,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2016", month: "04", day: "06" },
@@ -757,6 +812,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 2,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -774,6 +830,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },


### PR DESCRIPTION
Trello cards:
https://trello.com/c/eXfGf5lL/171-child-benefit-tax-calculator-add-question-part-year-and-complete-logic-for-answering-no

https://trello.com/c/KbE3axrr/172-child-benefit-tax-calculator-part-year-all-children-add-logic-for-answering-yes

This is following the work of @leenagupte in PR #141 
Merge #141 first before merging this PR.
This supersedes #142 

## Factcheck

[Preview link](https://calculators-pr-142.herokuapp.com/child-benefit-tax-calculator/main)
[Preview link for PR 141](https://calculators-pr-141.herokuapp.com/child-benefit-tax-calculator/main)
[GOV.UK](https://gov.uk/child-benefit-tax-calculator/main)

## Expected changes 

Create a new Question 3 that asks if any of the children are only being claimed for a part of the tax year.

### Before

#### GOV.UK


![screen shot 2016-06-13 at 17 03 53](https://cloud.githubusercontent.com/assets/84896/16014381/d7eda53e-3188-11e6-959c-6c3f3290df7f.png)


#### PR 141
![screen shot 2016-06-13 at 17 01 57](https://cloud.githubusercontent.com/assets/84896/16014304/936a11ae-3188-11e6-9e74-0f6f92e265cb.png)


### After

![screen shot 2016-06-13 at 17 00 43](https://cloud.githubusercontent.com/assets/84896/16014314/9aa099fc-3188-11e6-996c-467558dbb66d.png)



