### PR TITLE
Change monday rules

### DIFF
--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -37,8 +37,10 @@ class ChildBenefitTaxCalculator
     self.class.valid_date_params?(params)
   end
 
+  # Return the date of the Monday in the future that is closest to the date supplied.
+  # If the date supplied is a Monday, do not adjust it.
   def monday_on_or_after(date)
-    date + ((1 - date.wday) % 7)
+    date.monday? ? date : date.next_week(:monday)
   end
 
   def nothing_owed?
@@ -114,8 +116,10 @@ private
   end
 
   def eligible?(child, tax_year, week_start_date)
+    adjusted_start_date = monday_on_or_after(child.start_date)
+
     eligible_for_tax_year?(child, tax_year) &&
-      days_include_week?(child.adjusted_start_date, child.benefits_end, week_start_date)
+      days_include_week?(adjusted_start_date, child.benefits_end, week_start_date)
   end
 
   def eligible_for_tax_year?(child, tax_year)

--- a/app/models/starting_child.rb
+++ b/app/models/starting_child.rb
@@ -20,21 +20,6 @@ class StartingChild
     @end_date ? @end_date : tax_years[tax_years.keys.sort.last].last
   end
 
-  # Return the date of the Monday in the future that is closest to the start_date.
-  # If the start_date is a Monday, use the start_date.
-  def adjusted_start_date
-    return nil if start_date.nil?
-
-    if start_date.wday < 1
-      start_date + 1.day
-    elsif start_date.wday > 1
-      number_of_days_til_next_monday = ((1 - start_date.wday) + 7)
-      start_date + number_of_days_til_next_monday
-    else
-      start_date
-    end
-  end
-
 private
 
   def valid_dates

--- a/app/models/starting_child.rb
+++ b/app/models/starting_child.rb
@@ -20,10 +20,19 @@ class StartingChild
     @end_date ? @end_date : tax_years[tax_years.keys.sort.last].last
   end
 
-  # Return the next Monday if start_date is not nil.
+  # Return the date of the Monday in the future that is closest to the start_date.
+  # If the start_date is a Monday, use the start_date.
   def adjusted_start_date
     return nil if start_date.nil?
-    start_date + (start_date.wday < 1 ? 1 : (1 - start_date.wday) + 7)
+
+    if start_date.wday < 1
+      start_date + 1.day
+    elsif start_date.wday > 1
+      number_of_days_til_next_monday = ((1 - start_date.wday) + 7)
+      start_date + number_of_days_til_next_monday
+    else
+      start_date
+    end
   end
 
 private

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -54,7 +54,7 @@
         <fieldset id="children">
           <%= step(3, "Enter the Child Benefit start and stop dates:") %>
           <ul>
-            <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
+            <li>the start date is called an ‘effective date’ - you can find it on your Child Benefit award notice</li>
             <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
           </ul>
           <%= render "starting_children" %>

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -24,6 +24,32 @@ describe ChildBenefitTaxCalculator, type: :model do
     expect(calc.adjusted_net_income).to eq(100900)
   end
 
+  describe "#monday_on_or_after" do
+    subject { ChildBenefitTaxCalculator.new }
+
+    it "should return the tomorrow if the date is a Sunday" do
+      sunday = Date.parse("1 January 2012")
+      monday = Date.parse("2 January 2012")
+
+      expect(subject.monday_on_or_after(sunday)).to eq(monday)
+    end
+
+    it "should return today if today is a Monday" do
+      monday = Date.parse("2 January 2012")
+
+      expect(subject.monday_on_or_after(monday)).to eq(monday)
+    end
+
+    it "should return the following Monday for days between Tueday and Saturday" do
+      tuesday = Date.parse("3 January 2012")
+      saturday = Date.parse("7 January 2012")
+      next_monday = Date.parse("9 January 2012")
+
+      expect(subject.monday_on_or_after(tuesday)).to eq(next_monday)
+      expect(subject.monday_on_or_after(saturday)).to eq(next_monday)
+    end
+  end
+
   describe "input validation" do
     before(:each) do
       @calc = ChildBenefitTaxCalculator.new(children_count: "1")

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -488,10 +488,10 @@ describe ChildBenefitTaxCalculator, type: :model do
           },
         },
       )
-      expect(calc.benefits_claimed_amount.round(2)).to eq(598.90)
-      expect(calc.tax_estimate).to eq(359)
+      expect(calc.benefits_claimed_amount.round(2)).to eq(612.30)
+      expect(calc.tax_estimate).to eq(367)
     end
-    it "should calculate one week for one child observing the 'next Monday' rule." do
+    it "should calculate two weeks for one child observing the 'Monday' rules." do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: 1,
@@ -501,7 +501,7 @@ describe ChildBenefitTaxCalculator, type: :model do
             stop: { day: "21", month: "01", year: "2013" },
           },
         },
-      ).benefits_claimed_amount.round(2)).to eq(20.30)
+      ).benefits_claimed_amount.round(2)).to eq(40.60)
     end
     it "should calculate 3 children already in the household for 2013/2014" do
       calc = ChildBenefitTaxCalculator.new(
@@ -556,7 +556,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         children_count: 1,
         starting_children: {
           "0" => {
-            start: { day: "24", month: "06", year: "2013" },
+            start: { day: "01", month: "07", year: "2013" },
             stop: { day: "", month: "", year: "" },
           },
         },
@@ -651,7 +651,7 @@ describe ChildBenefitTaxCalculator, type: :model do
               stop: { day: "", month: "", year: "" },
             },
          },
-       ).benefits_claimed_amount.round(2)).to eq(2501.2)
+       ).benefits_claimed_amount.round(2)).to eq(2549.3)
       end
 
       it "should give the total amount of benefits received for a full tax year 2015" do
@@ -664,7 +664,7 @@ describe ChildBenefitTaxCalculator, type: :model do
               stop: { year: "2016", month: "04", day: "05" },
             },
           },
-        ).benefits_claimed_amount.round(2)).to eq(1076.4)
+        ).benefits_claimed_amount.round(2)).to eq(1097.1)
       end
 
       it "should give total amount of benefits one child full year one child half a year" do
@@ -681,7 +681,7 @@ describe ChildBenefitTaxCalculator, type: :model do
               stop: { day: "06", month: "11", year: "2016" },
             },
           },
-        ).benefits_claimed_amount.round(2)).to eq(1788.8)
+        ).benefits_claimed_amount.round(2)).to eq(1823.2)
       end
 
       it "should give total amount of benefits for one child for half a year" do
@@ -695,7 +695,7 @@ describe ChildBenefitTaxCalculator, type: :model do
             },
           },
         )
-        expect(calc.benefits_claimed_amount.round(2)).to eq(621.0)
+        expect(calc.benefits_claimed_amount.round(2)).to eq(641.7)
       end
     end
 

--- a/spec/models/starting_child_spec.rb
+++ b/spec/models/starting_child_spec.rb
@@ -45,29 +45,4 @@ describe StartingChild, type: :model do
     )
     expect(child).to be_valid
   end
-
-  describe "adjusted_start_date" do
-    it "should not adjust the start date if start date is a Monday" do
-      child = StartingChild.new(start: { year: "2013", month: "01", day: "07" })
-      expect(child.adjusted_start_date).to eq(Date.parse("07 January 2013"))
-    end
-
-    it "should return the next Monday for the provided start date" do
-      child = StartingChild.new(start: { year: "2012", month: "01", day: "01" })
-      expect(child.adjusted_start_date).to eq(Date.parse("2 January 2012"))
-
-      child = StartingChild.new(start: { year: "2013", month: "05", day: "08" })
-      expect(child.adjusted_start_date).to eq(Date.parse("13 May 2013"))
-
-      child = StartingChild.new(start: { year: "2013", month: "08", day: "13" })
-      expect(child.adjusted_start_date).to eq(Date.parse("19 August 2013"))
-
-      child = StartingChild.new(start: { year: "2013", month: "01", day: "06" })
-      expect(child.adjusted_start_date).to eq(Date.parse("7 January 2013"))
-    end
-
-    it "should not blow up with a nil start date" do
-      expect(StartingChild.new(start: {}).adjusted_start_date).to be_nil
-    end
-  end
 end

--- a/spec/models/starting_child_spec.rb
+++ b/spec/models/starting_child_spec.rb
@@ -47,9 +47,9 @@ describe StartingChild, type: :model do
   end
 
   describe "adjusted_start_date" do
-    it "should return the next Monday if start date is 7th January 2013" do
+    it "should not adjust the start date if start date is a Monday" do
       child = StartingChild.new(start: { year: "2013", month: "01", day: "07" })
-      expect(child.adjusted_start_date).to eq(Date.parse("14 January 2013"))
+      expect(child.adjusted_start_date).to eq(Date.parse("07 January 2013"))
     end
 
     it "should return the next Monday for the provided start date" do
@@ -64,9 +64,6 @@ describe StartingChild, type: :model do
 
       child = StartingChild.new(start: { year: "2013", month: "01", day: "06" })
       expect(child.adjusted_start_date).to eq(Date.parse("7 January 2013"))
-
-      child = StartingChild.new(start: { year: "2013", month: "01", day: "14" })
-      expect(child.adjusted_start_date).to eq(Date.parse("21 January 2013"))
     end
 
     it "should not blow up with a nil start date" do


### PR DESCRIPTION
Superseeds: PR #143 

Trello story: https://trello.com/c/NqFHIT6z/169-child-benefit-tax-calculator-change-which-mondays-are-included-in-the-calculation

## Factcheck
[Child benefit tax calculator](https://calculators-pr-143.herokuapp.com/child-benefit-tax-calculator/main?childcare=&children_count=1&cycle_scheme=&gift_aid_donations=&gross_income=&non_employment_income=&other_income=&outgoing_pension_contributions=&pension_contributions_from_pay=&pensions=&property=&results=Calculate&retirement_annuities=&starting_children%5B0%5D%5Bstart%5D%5Bday%5D=13&starting_children%5B0%5D%5Bstart%5D%5Bmonth%5D=6&starting_children%5B0%5D%5Bstart%5D%5Byear%5D=2016&starting_children%5B0%5D%5Bstop%5D%5Bday%5D=&starting_children%5B0%5D%5Bstop%5D%5Bmonth%5D=&starting_children%5B0%5D%5Bstop%5D%5Byear%5D=&year=2016#results)

## Expected Changes
[URL on GOV.UK](https://www.gov.uk/child-benefit-tax-calculator/main)
    * Changes the rules for which Mondays are included in the calculation. If the start date is Monday, include it in the calculation.

## Before

### Copy Change
![screen shot 2016-06-16 at 12 16 33](https://cloud.githubusercontent.com/assets/5793815/16114987/31caf45a-33bc-11e6-90b9-b44913ae2ad4.png)

### Results
One child
Tax year is 2016 - 2017
Start date is 13/06/2016

![screen shot 2016-06-16 at 12 13 49](https://cloud.githubusercontent.com/assets/5793815/16114918/d3246d8c-33bb-11e6-9ded-07392744388d.png)

## After

### Copy Changes
![screen shot 2016-06-16 at 12 15 41](https://cloud.githubusercontent.com/assets/5793815/16114966/1592f3c8-33bc-11e6-81cd-7953a698bea6.png)

One child
Tax year is 2016 - 2017
Start date is 13/06/2016

### Results
![screen shot 2016-06-16 at 12 14 51](https://cloud.githubusercontent.com/assets/5793815/16114936/f36cf294-33bb-11e6-87db-7dbe1ec4efe0.png)