### PR TITLE
Question 3 part year tax claim

### DIFF
--- a/app/assets/javascripts/child-benefit-tax-calculator.js
+++ b/app/assets/javascripts/child-benefit-tax-calculator.js
@@ -1,4 +1,4 @@
-(function () {
+(function() {
   "use strict";
 
   var root = this,
@@ -7,17 +7,41 @@
 
   var calculator = {
     childrenCountInput: $("#children_count"),
-    childrenContainer: $("fieldset#children"),
-
-    setEventHandlers: function () {
-      calculator.childrenCountInput.on('change', calculator.updateChildrenFields);
+    childrenContainerTemplate: $("div#children-template"),
+    taxClaimContainer: $("fieldset#is-part-year-claim"),
+    taxClaimDurationInputs: $("input[id^='is_part_year_claim_']"),
+    childrenContainer: function() {
+      return $("div#children");
     },
-    updateChildrenFields: function () {
+    setEventHandlers: function() {
+      calculator.childrenCountInput.on('change', calculator.updateChildrenFields);
+      calculator.taxClaimDurationInputs.on('change', calculator.triggerChildrenFieldsEvent);
+      calculator.setUpForm();
+    },
+    setUpForm: function(){
+      var choosenTaxClaim = calculator.taxClaimDurationInputs.filter(":checked").val();
+      calculator.toggleChildrenFields(choosenTaxClaim);
+    },
+    triggerChildrenFieldsEvent: function(event){
+      calculator.toggleChildrenFields($(event.currentTarget).val());
+    },
+    toggleChildrenFields: function(choosen){
+      if (choosen == "yes") {
+        if (calculator.childrenContainer().length == 0) {
+          var childrenTag = calculator.childrenContainerTemplate.clone();
+          calculator.taxClaimContainer.append(childrenTag);
+          childrenTag.attr("id", "children").show();
+          calculator.updateChildrenFields();
+        }
+      } else {
+        calculator.childrenContainer().remove();
+      }
+    },
+    updateChildrenFields: function() {
       var numStartingChildren = calculator.childrenCountInput.val(),
-        childFields = calculator.childrenContainer.find('> div.child'),
+        childFields = calculator.childrenContainer().find("> div.child"),
         numChildFields = childFields.size(),
         numNewFields = numStartingChildren - numChildFields;
-
       if (numStartingChildren < 1 || numStartingChildren > 10) {
         return false;
       }
@@ -31,7 +55,7 @@
         }
       }
     },
-    appendChildField: function (index) {
+    appendChildField: function(index) {
       var newChild = calculator.childFieldToClone().clone();
 
       newChild.find('.child-number').text(index+1);
@@ -44,14 +68,14 @@
         $(this).attr('for', calculator.replaceIndex(index, $(this).attr('for')));
       });
 
-      newChild.appendTo(calculator.childrenContainer);
+      newChild.appendTo(calculator.childrenContainer());
     },
-    childFieldToClone: function () {
+    childFieldToClone: function() {
       // Always clone the first field so that we don't have to guess
       // the index (it will always be zero)
-      return calculator.childrenContainer.find("> div.child").first();
+      return calculator.childrenContainer().find("> div.child").first();
     },
-    replaceIndex: function (index, str) {
+    replaceIndex: function(index, str) {
       return str.replace("0", index);
     }
   };

--- a/app/assets/stylesheets/calculators/child_benefit.scss
+++ b/app/assets/stylesheets/calculators/child_benefit.scss
@@ -104,6 +104,7 @@ li {
   // scss-lint:disable IdSelector
   #children {
     margin-bottom: 0;
+    float: left;
 
     h3 {
       @include bold-19;

--- a/app/models/adjusted_net_income_calculator.rb
+++ b/app/models/adjusted_net_income_calculator.rb
@@ -2,7 +2,7 @@
 class AdjustedNetIncomeCalculator
   PARAM_KEYS = [:gross_income, :other_income, :pension_contributions_from_pay,
                 :retirement_annuities, :cycle_scheme, :childcare, :pensions, :property,
-                :non_employment_income, :gift_aid_donations, :outgoing_pension_contributions]
+                :non_employment_income, :gift_aid_donations, :outgoing_pension_contributions, :is_part_year_claim]
 
   def initialize(params)
     PARAM_KEYS.each do |key|

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -50,14 +50,21 @@
             <% end -%>
           </div>
         </fieldset>
-
-        <fieldset id="children">
-          <%= step(3, "Enter the Child Benefit start and stop dates:") %>
-          <ul>
-            <li>the start date is called an ‘effective date’ - you can find it on your Child Benefit award notice</li>
-            <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
-          </ul>
-          <%= render "starting_children" %>
+        
+        <fieldset id="is-part-year-claim">
+          <%= step(3, "Choose a tax claim duration:") %>
+          <p>Are you claiming for a part of the tax year for any of your children?</p>
+          <div class="is-part-year-claim<% if @calculator.errors.has_key?(:is_part_year_claim) %> validation-error<% end %>">
+            <% @calculator.errors[:is_part_year_claim].each do |message| %>
+              <p><%= message %></p>
+            <% end -%>
+            <% ["yes", "no"].each do |option| -%>
+              <label for="is_part_year_claim_<%= option %>" class="selectable">
+                <%= radio_button_tag "is_part_year_claim", option, (@calculator.is_part_year_claim == option) %>
+                <%= option.capitalize %>
+              </label>
+            <% end -%>
+          </div>
         </fieldset>
 
         <fieldset id="adjusted_income">
@@ -93,6 +100,14 @@
 
         <%= submit_tag "Calculate", :name => "results", :class => "button" %>
       <% end %>
+      <div id="children-template" style="display:none">
+        <h2>Enter the Child Benefit start and stop dates:</h2>
+        <ul>
+          <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
+          <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
+        </ul>
+        <%= render "starting_children" %>
+      </div>
 
       <% if can_haz_results? -%>
       <div class="results">

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -15,6 +15,7 @@ describe ChildBenefitTaxCalculator, type: :model do
   it "is valid if given enough detail" do
     expect(ChildBenefitTaxCalculator.new(
       year: "2012", children_count: "1",
+      is_part_year_claim: "yes",
       starting_children: { "0" => { start: { year: "2011", month: "01", day: "01" } } },
     ).can_calculate?).to eq(true)
   end
@@ -52,7 +53,7 @@ describe ChildBenefitTaxCalculator, type: :model do
 
   describe "input validation" do
     before(:each) do
-      @calc = ChildBenefitTaxCalculator.new(children_count: "1")
+      @calc = ChildBenefitTaxCalculator.new(children_count: "1", is_part_year_claim: "no")
       @calc.valid?
     end
     it "should contain errors for year if none is given" do
@@ -76,6 +77,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc = ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -91,6 +93,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc = ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -106,6 +109,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc = ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "3",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -131,7 +135,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(@calc.errors.size).to eq(1)
       end
       it "should be true if any starting children have errors" do
-        calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1")
+        calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1", is_part_year_claim: "yes")
         calc.valid?
         expect(calc.errors).to be_empty
         #puts calc.starting_children.first.errors.full_messages
@@ -141,6 +145,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2012",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2012", month: "01", day: "07" } },
           },
@@ -161,7 +166,13 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(calc.errors).to be_empty
       end
       it "should not contain errors if tax claim duration is set to yes" do
-        calc = ChildBenefitTaxCalculator.new(children_count: "1", year: 2012, is_part_year_claim: "yes")
+        calc = ChildBenefitTaxCalculator.new(children_count: "1",
+            year: 2012,
+            is_part_year_claim: "yes",
+            starting_children: {
+              "0" => { start: { year: "2012", month: "01", day: "07" } },
+            }
+          )
         calc.valid?
         expect(calc.errors).to be_empty
       end
@@ -173,6 +184,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "02", day: "01" },
@@ -185,6 +197,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2013", month: "04", day: "06" },
@@ -197,6 +210,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -209,6 +223,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "2",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -230,6 +245,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         other_income: "0",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).adjusted_net_income).to eq(50099)
     end
 
@@ -247,6 +263,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         childcare: "£1500",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).adjusted_net_income).to eq(66950)
     end
 
@@ -265,6 +282,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         childcare: "£1500",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).adjusted_net_income).to eq(66950)
     end
   end
@@ -275,6 +293,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "50099",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(0.0)
     end
     it "should be 1.0 for an income of 50199" do
@@ -282,6 +301,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "50199",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(1.0)
     end
     it "should be 2.0 for an income of 50200" do
@@ -289,6 +309,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "50200",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(2.0)
     end
     it "should be 40.0 for an income of 54013" do
@@ -296,6 +317,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "54013",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(40.0)
     end
     it "should be 40.0 for an income of 54089" do
@@ -303,12 +325,14 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "54089",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(40.0)
     end
     it "should be 99.0 for an income of 59999" do
       expect(ChildBenefitTaxCalculator.new(
         adjusted_net_income: "59999",
         year: "2012",
+        is_part_year_claim: "no",
         children_count: 2,
       ).percent_tax_charge).to eq(99.0)
     end
@@ -317,6 +341,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "60000",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(100.0)
     end
     it "should be 100.0 for an income of 60001" do
@@ -324,6 +349,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "60001",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(100.0)
     end
   end
@@ -333,6 +359,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "should be true for incomes under the threshold" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "49999",
+          is_part_year_claim: "yes",
           children_count: 1,
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
@@ -343,6 +370,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "should be true for incomes over the threshold" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "50100",
+          is_part_year_claim: "yes",
           children_count: 1,
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
@@ -356,6 +384,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "calculates the correct amount owed for % charge of 100" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "60001",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -367,6 +396,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "59900",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -378,6 +408,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "54000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -391,6 +422,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "60001",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -402,6 +434,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "59900",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -413,6 +446,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "54000",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2011", month: "01", day: "01" },
@@ -432,6 +466,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "03", day: "01" },
@@ -447,6 +482,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2012", month: "05", day: "01" },
@@ -462,6 +498,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "02", day: "01" },
@@ -480,6 +517,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "02", day: "22" },
@@ -499,6 +537,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: 3,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
@@ -518,7 +557,9 @@ describe ChildBenefitTaxCalculator, type: :model do
     it "should calculate 3 children for 2012/2013 one child starting on 7 Jan 2013" do
       calc = ChildBenefitTaxCalculator.new(
         adjusted_net_income: "56000",
-        year: "2012", children_count: 3, starting_children: {
+        year: "2012", children_count: 3,
+        is_part_year_claim: "yes",
+        starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
             stop: { day: "05", month: "04", year: "2013" },
@@ -540,6 +581,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: 1,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "14", month: "01", year: "2013" },
@@ -553,6 +595,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "52000",
         year: "2013",
         children_count: 3,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -576,6 +619,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "53000",
         year: "2013",
         children_count: 3,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -599,6 +643,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "61000",
         year: "2013",
         children_count: 1,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "01", month: "07", year: "2013" },
@@ -615,6 +660,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 3,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -636,6 +682,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "04", day: "06" },
@@ -649,6 +696,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 2,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -666,6 +714,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -682,6 +731,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 3,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -703,6 +753,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2015", month: "04", day: "06" },
@@ -716,6 +767,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 2,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -733,6 +785,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -749,6 +802,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 3,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -770,6 +824,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2016", month: "04", day: "06" },
@@ -783,6 +838,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 2,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -800,6 +856,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -147,6 +147,25 @@ describe ChildBenefitTaxCalculator, type: :model do
         ).has_errors?).to eq(false)
       end
     end
+
+    describe "#is_part_year_claim" do
+      it "should contain errors if tax claim duration is not provided" do
+        calc = ChildBenefitTaxCalculator.new(children_count: "1", year: 2012)
+        calc.valid?
+        expect(calc.errors).to have_key(:is_part_year_claim)
+        expect(calc.errors.size).to eq(1)
+      end
+      it "should not contain errors if tax claim duration is set to no" do
+        calc = ChildBenefitTaxCalculator.new(children_count: "1", year: 2012, is_part_year_claim: "no")
+        calc.valid?
+        expect(calc.errors).to be_empty
+      end
+      it "should not contain errors if tax claim duration is set to yes" do
+        calc = ChildBenefitTaxCalculator.new(children_count: "1", year: 2012, is_part_year_claim: "yes")
+        calc.valid?
+        expect(calc.errors).to be_empty
+      end
+    end
   end
 
   describe "calculating benefits received" do
@@ -789,6 +808,33 @@ describe ChildBenefitTaxCalculator, type: :model do
           },
         )
         expect(calc.benefits_claimed_amount.round(2)).to eq(621.0)
+      end
+
+      it "should set the start date to start of the selected tax year" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2015",
+          children_count: 1,
+          is_part_year_claim: "no"
+        )
+
+        expect(calc.child_benefit_start_date).to eq(Date.parse("06 April 2015"))
+        expect(calc.child_benefit_end_date).to eq(Date.parse("05 April 2016"))
+      end
+
+      it "should set the stop date to end of the selected tax year" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2015",
+          children_count: 1,
+          is_part_year_claim: "yes",
+          starting_children: {
+            "0" => {
+              start: { day: "06", month: "04", year: "2015" },
+              stop: { day: "", month: "", year: "" },
+            },
+          },
+        )
+
+        expect(calc.child_benefit_end_date).to eq(Date.parse("05 April 2016"))
       end
     end
   end


### PR DESCRIPTION
Trello cards:
https://trello.com/c/eXfGf5lL/171-child-benefit-tax-calculator-add-question-part-year-and-complete-logic-for-answering-no

https://trello.com/c/KbE3axrr/172-child-benefit-tax-calculator-part-year-all-children-add-logic-for-answering-yes

This supersedes #144 

## Factcheck

[Preview link](https://calculators-pr-142.herokuapp.com/child-benefit-tax-calculator/main)
[GOV.UK](https://gov.uk/child-benefit-tax-calculator/main)

## Expected changes 

Create a new Question 3 that asks if any of the children are only being claimed for a part of the tax year.

### Before

#### GOV.UK


![screen shot 2016-06-13 at 17 03 53](https://cloud.githubusercontent.com/assets/84896/16014381/d7eda53e-3188-11e6-959c-6c3f3290df7f.png)

### After

![screen shot 2016-06-13 at 17 00 43](https://cloud.githubusercontent.com/assets/84896/16014314/9aa099fc-3188-11e6-996c-467558dbb66d.png)



