### PR TITLE
Ask how many children are only being claimed for part of the year

### DIFF
--- a/app/assets/javascripts/child-benefit-tax-calculator.js
+++ b/app/assets/javascripts/child-benefit-tax-calculator.js
@@ -7,6 +7,9 @@
 
   var calculator = {
     childrenCountInput: $("#children_count"),
+    partYearChildrenCountInput: function(){
+      return $("div#children #part_year_children_count")
+    },
     childrenContainerTemplate: $("div#children-template"),
     taxClaimContainer: $("fieldset#is-part-year-claim"),
     taxClaimDurationInputs: $("input[id^='is_part_year_claim_']"),
@@ -14,7 +17,6 @@
       return $("div#children");
     },
     setEventHandlers: function() {
-      calculator.childrenCountInput.on('change', calculator.updateChildrenFields);
       calculator.taxClaimDurationInputs.on('change', calculator.triggerChildrenFieldsEvent);
       calculator.setUpForm();
     },
@@ -31,14 +33,16 @@
           var childrenTag = calculator.childrenContainerTemplate.clone();
           calculator.taxClaimContainer.append(childrenTag);
           childrenTag.attr("id", "children").show();
+          calculator.partYearChildrenCountInput().on('change', calculator.updateChildrenFields);
           calculator.updateChildrenFields();
         }
       } else {
+        calculator.partYearChildrenCountInput().off('change');
         calculator.childrenContainer().remove();
       }
     },
     updateChildrenFields: function() {
-      var numStartingChildren = calculator.childrenCountInput.val(),
+      var numStartingChildren = calculator.partYearChildrenCountInput().val(),
         childFields = calculator.childrenContainer().find("> div.child"),
         numChildFields = childFields.size(),
         numNewFields = numStartingChildren - numChildFields;

--- a/app/controllers/child_benefit_tax_controller.rb
+++ b/app/controllers/child_benefit_tax_controller.rb
@@ -1,7 +1,7 @@
 class ChildBenefitTaxController < ApplicationController
   before_filter :setup_slimmer
 
-  CALC_PARAM_KEYS = [:adjusted_net_income, :children_count, :starting_children, :year, :results] +
+  CALC_PARAM_KEYS = [:adjusted_net_income, :children_count, :starting_children, :year, :results, :part_year_children_count] +
     AdjustedNetIncomeCalculator::PARAM_KEYS
 
   def landing

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -29,8 +29,8 @@ class ChildBenefitTaxCalculator
     @children_count = params[:children_count] ? params[:children_count].to_i : 1
     @part_year_children_count = params[:part_year_children_count] ? params[:part_year_children_count].to_i : 0
     @is_part_year_claim = params[:is_part_year_claim]
-    @starting_children = process_starting_children(params[:starting_children])
     @tax_year = params[:year].to_i
+    @starting_children = process_starting_children(params[:starting_children])
   end
 
   def self.valid_date_params?(params)
@@ -91,11 +91,15 @@ class ChildBenefitTaxCalculator
 
   def benefits_claimed_amount
     all_weeks_children = {}
+    full_year_children = @children_count - @part_year_children_count
     (child_benefit_start_date...child_benefit_end_date).each_slice(7) do |week|
       monday = monday_on_or_after(week.first)
       all_weeks_children[monday] = 0
       @starting_children.each do |child|
         all_weeks_children[monday] += 1 if eligible?(child, tax_year, monday)
+      end
+      full_year_children.times do
+        all_weeks_children[monday] += 1
       end
     end
     # calculate total for all weeks
@@ -112,8 +116,14 @@ class ChildBenefitTaxCalculator
 private
 
   def process_starting_children(children)
+    if selected_tax_year.present?
+      number_of_children = @part_year_children_count
+    else
+      number_of_children = @children_count
+    end
+
     [].tap do |ary|
-      @children_count.times do |n|
+      number_of_children.times do |n|
         if children && children[n.to_s] && valid_date_params?(children[n.to_s][:start])
           ary << StartingChild.new(children[n.to_s])
         else

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -181,7 +181,7 @@ private
   end
 
   def valid_child_dates
-    @starting_children.each(&:valid?)
+    is_part_year_claim == 'yes' && @starting_children.each(&:valid?)
   end
 
   def tax_year_contains_at_least_one_child

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -78,7 +78,7 @@ class ChildBenefitTaxCalculator
   end
 
   def can_calculate?
-    valid? && !has_errors? && @starting_children.any?
+    valid? && !has_errors?
   end
 
   def selected_tax_year

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -20,12 +20,14 @@ class ChildBenefitTaxCalculator
   validate :valid_child_dates
   validates_presence_of :is_part_year_claim, message: "select part year tax claim"
   validates_inclusion_of :tax_year, in: TAX_YEARS.keys.map(&:to_i), message: "select a tax year"
+  validate :valid_number_of_children
   validate :tax_year_contains_at_least_one_child
 
   def initialize(params = {})
     @adjusted_net_income_calculator = AdjustedNetIncomeCalculator.new(params)
     @adjusted_net_income = calculate_adjusted_net_income(params[:adjusted_net_income])
     @children_count = params[:children_count] ? params[:children_count].to_i : 1
+    @part_year_children_count = params[:part_year_children_count] ? params[:part_year_children_count].to_i : 0
     @is_part_year_claim = params[:is_part_year_claim]
     @starting_children = process_starting_children(params[:starting_children])
     @tax_year = params[:year].to_i
@@ -182,6 +184,12 @@ private
 
   def valid_child_dates
     is_part_year_claim == 'yes' && @starting_children.each(&:valid?)
+  end
+
+  def valid_number_of_children
+    if @is_part_year_claim == 'yes' && (@children_count < @part_year_children_count)
+      errors.add(:part_year_children_count, "The number of children being claimed cannot exceed the total number of children being claimed for.")
+    end
   end
 
   def tax_year_contains_at_least_one_child

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -4,7 +4,7 @@ class ChildBenefitTaxCalculator
   include ActiveModel::Validations
 
   attr_reader :adjusted_net_income_calculator, :adjusted_net_income, :children_count,
-    :starting_children, :tax_year, :is_part_year_claim
+    :starting_children, :tax_year, :is_part_year_claim, :part_year_children_count
 
   NET_INCOME_THRESHOLD = 50000
   TAX_COMMENCEMENT_DATE = Date.parse('7 Jan 2013')

--- a/app/views/child_benefit_tax/_starting_children.html.erb
+++ b/app/views/child_benefit_tax/_starting_children.html.erb
@@ -1,9 +1,16 @@
-<% @calculator.starting_children.each_with_index do |child, index| -%>
-  <div class="child<% if child.errors.any? %> validation-error<% end -%>">
-    <% child.errors.each do |key, message| -%>
-      <p><%= message %></p>
-    <% end -%>
-    <h3>Child <span class="child-number"><%= index + 1 %></span></h3>
-    <%= render "starting_child", :index => index, :child => child %>
+<% if @calculator.starting_children.count == 0 %>
+  <div class="child">
+    <h3>Child <span class="child-number"> 1 </span></h3>
+    <%= render "starting_child", index: 0, child: StartingChild.new  %>
   </div>
-<% end -%>
+<% else %>
+  <% @calculator.starting_children.each_with_index do |child, index| -%>
+    <div class="child<% if child.errors.any? %> validation-error<% end -%>">
+      <% child.errors.each do |key, message| -%>
+        <p><%= message %></p>
+      <% end -%>
+      <h3>Child <span class="child-number"><%= index + 1 %></span></h3>
+      <%= render "starting_child", :index => index, :child => child %>
+    </div>
+  <% end -%>
+<% end %>

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -101,6 +101,12 @@
         <%= submit_tag "Calculate", :name => "results", :class => "button" %>
       <% end %>
       <div id="children-template" style="display:none">
+        <div class="part-year-children-count">
+          <h2>Enter the number of children only being claimed for part of the year:<h2>
+          <label for="part_year_children_count" class="visuallyhidden">Number of part year children</label>
+          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}) %>
+        </div>
+
         <h2>Enter the Child Benefit start and stop dates:</h2>
         <ul>
           <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -104,7 +104,8 @@
         <div class="part-year-children-count">
           <h2>Enter the number of children only being claimed for part of the year:<h2>
           <label for="part_year_children_count" class="visuallyhidden">Number of part year children</label>
-          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}) %>
+          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}, @calculator.children_count) %>
+          <%= submit_tag "Update Children", :name => "children", :class => "button update-button" %>
         </div>
 
         <h2>Enter the Child Benefit start and stop dates:</h2>

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -104,7 +104,7 @@
         <div class="part-year-children-count">
           <h2>Enter the number of children only being claimed for part of the year:<h2>
           <label for="part_year_children_count" class="visuallyhidden">Number of part year children</label>
-          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}, @calculator.children_count) %>
+          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}, @calculator.part_year_children_count) %>
           <%= submit_tag "Update Children", :name => "children", :class => "button update-button" %>
         </div>
 

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -108,6 +108,14 @@ feature "Child Benefit Tax Calculator", js: true do
           end
         end
       end
+      it "should ask how many children are being claimed for a part year" do
+        choose "Yes"
+        within "#is-part-year-claim" do
+          within "#children" do
+            expect(page).to have_select("part_year_children_count")
+          end
+        end
+      end
     end
   end
 

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -589,6 +589,40 @@ feature "Child Benefit Tax Calculator", js: true do
     end # ANI below threshold
   end
 
+  describe "displaying results for full year children only" do
+    before(:each) do
+      visit "/child-benefit-tax-calculator"
+      click_on "Start now"
+    end
+
+    context "one child" do
+      it "should correctly display the amount for one child" do
+        choose "year_2015"
+        choose "No"
+
+        click_button "Calculate"
+
+        within ".results" do
+          expect(page).to have_content("£1,097.10")
+        end
+      end
+    end
+
+    context "two children" do
+      it "should correctly display the amount for two children" do
+        select "2", from: "children_count"
+        choose "year_2015"
+        choose "No"
+
+        click_button "Calculate"
+
+        within ".results" do
+          expect(page).to have_content("£1,823.20")
+        end
+      end
+    end
+  end
+
   describe "child benefit week runs Monday to Sunday" do
     before(:each) do
       visit "/child-benefit-tax-calculator"

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -46,7 +46,8 @@ feature "Child Benefit Tax Calculator", js: true do
         click_on "Calculate"
         within ".validation-summary" do
           expect(page).to have_content("select a tax year")
-          expect(page).to have_content("enter the date Child Benefit started")
+          expect(page).to have_content("select part year tax claim")
+          expect(page).to have_no_content("enter the date Child Benefit started")
         end
 
         within "#tax-year" do
@@ -68,7 +69,7 @@ feature "Child Benefit Tax Calculator", js: true do
         click_on "Calculate"
         within ".validation-summary" do
           expect(page).to have_content("select a tax year")
-          expect(page).to have_content("enter the date Child Benefit started")
+          expect(page).to have_no_content("enter the date Child Benefit started")
         end
 
         within "#tax-year" do
@@ -108,11 +109,30 @@ feature "Child Benefit Tax Calculator", js: true do
           end
         end
       end
+
       it "should ask how many children are being claimed for a part year" do
         choose "Yes"
         within "#is-part-year-claim" do
           within "#children" do
             expect(page).to have_select("part_year_children_count")
+          end
+        end
+      end
+      it "should show two date selectors if two part year children are selected" do
+        choose "Yes"
+        select "2", from: "part_year_children_count"
+        click_button "Update Children"
+
+        within "#is-part-year-claim" do
+          within "#children" do
+            expect(page).to have_select("part_year_children_count", selected: "2")
+
+            expect(page).to have_css("#starting_children_0_start_year")
+            expect(page).to have_css("#starting_children_0_start_month")
+            expect(page).to have_css("#starting_children_0_start_day")
+            expect(page).to have_css("#starting_children_1_start_year")
+            expect(page).to have_css("#starting_children_1_start_month")
+            expect(page).to have_css("#starting_children_1_start_day")
           end
         end
       end
@@ -125,7 +145,7 @@ feature "Child Benefit Tax Calculator", js: true do
     click_on "Start now"
     choose "Yes"
 
-    select "2", from: "children_count"
+    select "2", from: "part_year_children_count"
 
     select "2012", from: "starting_children[0][start][year]"
     select "February", from: "starting_children[0][start][month]"
@@ -166,8 +186,8 @@ feature "Child Benefit Tax Calculator", js: true do
     click_on "Start now"
     choose "Yes"
 
-    select "1", from: "children_count"
-    click_button "Update"
+    select "1", from: "part_year_children_count"
+    click_button "Update Children"
 
     page.find("#starting_children_0_start_year").select("2011")
     page.find("#starting_children_0_start_month").select("January")
@@ -195,12 +215,12 @@ feature "Child Benefit Tax Calculator", js: true do
       visit "/child-benefit-tax-calculator"
       click_on "Start now"
       choose "Yes"
-      select "2", from: "children_count"
-      click_button "Update"
+      select "2", from: "part_year_children_count"
+      click_button "Update Children"
     end
 
     it "should show the required number of date inputs" do
-      expect(page).to have_select("children_count", selected: "2")
+      expect(page).to have_select("part_year_children_count", selected: "2")
 
       expect(page).to have_css("#starting_children_0_start_year")
       expect(page).to have_css("#starting_children_0_start_month")
@@ -213,11 +233,11 @@ feature "Child Benefit Tax Calculator", js: true do
       page.find("#starting_children_0_start_month").select("January")
       page.find("#starting_children_0_start_day").select("1")
 
-      select "3", from: "children_count"
+      select "3", from: "part_year_children_count"
 
-      click_button "Update"
+      click_button "Update Children"
 
-      expect(page).to have_select("children_count", selected: "3")
+      expect(page).to have_select("part_year_children_count", selected: "3")
 
       expect(page).to have_select("starting_children_0_start_year", selected: "2011")
       expect(page).to have_select("starting_children_0_start_month", selected: "January")
@@ -231,9 +251,9 @@ feature "Child Benefit Tax Calculator", js: true do
       select "January", from: "starting_children_1_start_month"
       select "7", from: "starting_children_1_start_day"
 
-      select "1", from: "children_count"
+      select "1", from: "part_year_children_count"
 
-      click_button "Update"
+      click_button "Update Children"
 
       expect(page).to have_no_css("#starting_children_1_start_year")
       expect(page).to have_no_css("#starting_children_1_start_month")
@@ -241,7 +261,11 @@ feature "Child Benefit Tax Calculator", js: true do
     end
 
     it "should show the required number of date inputs without reloading the page" do
-      expect(page).to have_select("children_count", selected: "2")
+      choose "Yes"
+      select "2", from: "part_year_children_count"
+      click_button "Update Children"
+
+      expect(page).to have_select("part_year_children_count", selected: "2")
 
       expect(page).to have_css("#starting_children_0_start_year")
       expect(page).to have_css("#starting_children_0_start_month")
@@ -254,7 +278,7 @@ feature "Child Benefit Tax Calculator", js: true do
       page.find("#starting_children_0_start_month").select("January")
       page.find("#starting_children_0_start_day").select("1")
 
-      select "3", from: "children_count"
+      select "3", from: "part_year_children_count"
 
       expect(page).to have_select("starting_children_0_start_year", selected: "2011")
       expect(page).to have_select("starting_children_0_start_month", selected: "January")
@@ -268,7 +292,7 @@ feature "Child Benefit Tax Calculator", js: true do
       select "January", from: "starting_children_1_start_month"
       select "7", from: "starting_children_1_start_day"
 
-      select "1", from: "children_count"
+      select "1", from: "part_year_children_count"
 
       expect(page).to have_no_css("#starting_children_1_start_year")
       expect(page).to have_no_css("#starting_children_1_start_month")
@@ -281,6 +305,10 @@ feature "Child Benefit Tax Calculator", js: true do
       end
 
       it "calculates the overall benefits received for both children" do
+        choose "Yes"
+        select "2", from: "part_year_children_count"
+        click_button "Update Children"
+
         select "2011", from: "starting_children_0_start_year"
         select "January", from: "starting_children_0_start_month"
         select "1", from: "starting_children_0_start_day"
@@ -288,6 +316,7 @@ feature "Child Benefit Tax Calculator", js: true do
         select "2012", from: "starting_children_1_start_year"
         select "February", from: "starting_children_1_start_month"
         select "5", from: "starting_children_1_start_day"
+
         choose "year_2012"
 
         click_button "Calculate"

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -305,6 +305,7 @@ feature "Child Benefit Tax Calculator", js: true do
       end
 
       it "calculates the overall benefits received for both children" do
+        select "2", from: "children_count"
         choose "Yes"
         select "2", from: "part_year_children_count"
         click_button "Update Children"

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -253,28 +253,14 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
-        is_part_year_claim: "yes",
-        part_year_children_count: "1",
-        starting_children: {
-          "0" => {
-            start: { year: "2011", month: "02", day: "01" },
-            stop: { year: "2013", month: "05", day: "01" },
-          },
-        },
+        is_part_year_claim: "no"
       ).benefits_claimed_amount.round(2)).to eq(263.9)
     end
     it "should give the total amount of benefits received for a full tax year 2013" do
       expect(ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
-        is_part_year_claim: "yes",
-        part_year_children_count: "1",
-        starting_children: {
-          "0" => {
-            start: { year: "2013", month: "04", day: "06" },
-            stop: { year: "2014", month: "04", day: "05" },
-          },
-        },
+        is_part_year_claim: "no"
       ).benefits_claimed_amount.round(2)).to eq(1055.6)
     end
     it "should give the total amount of benefits received for a partial tax year" do
@@ -684,22 +670,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "52000",
         year: "2013",
         children_count: 3,
-        is_part_year_claim: "yes",
-        part_year_children_count: "3",
-        starting_children: {
-          "0" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-          "1" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-          "2" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-        },
+        is_part_year_claim: "no"
       )
       expect(calc.benefits_claimed_amount.round(2)).to eq(2449.20)
       expect(calc.tax_estimate.round(2)).to eq(489)
@@ -710,17 +681,9 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: 3,
         is_part_year_claim: "yes",
-        part_year_children_count: "3",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-          "1" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-          "2" => {
             start: { day: "06", month: "04", year: "2013" },
             stop: { day: "14", month: "06", year: "2013" },
           },
@@ -752,22 +715,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 3,
-          is_part_year_claim: "yes",
-          part_year_children_count: "3",
-          starting_children: {
-            "0" => {
-              start: { day: "06", month: "04", year: "2014" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
-              start: { day: "06", month: "04", year: "2014" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "2" => {
-              start: { day: "06", month: "04", year: "2014" },
-              stop: { day: "", month: "", year: "" },
-            },
-         },
+          is_part_year_claim: "no"
        ).benefits_claimed_amount.round(2)).to eq(2475.2)
       end
 
@@ -775,14 +723,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: "1",
-          is_part_year_claim: "yes",
-          part_year_children_count: "1",
-          starting_children: {
-            "0" => {
-              start: { year: "2014", month: "04", day: "06" },
-              stop: { year: "2015", month: "04", day: "05" },
-            },
-          },
+          is_part_year_claim: "no"
         ).benefits_claimed_amount.round(2)).to eq(1066.0)
       end
 
@@ -791,13 +732,9 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: 2,
           is_part_year_claim: "yes",
-          part_year_children_count: "2",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
-              start: { day: "06", month: "04", year: "2014" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
               start: { day: "06", month: "04", year: "2014" },
               stop: { day: "06", month: "11", year: "2014" },
             },
@@ -827,22 +764,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 3,
-          is_part_year_claim: "yes",
-          part_year_children_count: "3",
-          starting_children: {
-            "0" => {
-              start: { day: "06", month: "04", year: "2015" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
-              start: { day: "06", month: "04", year: "2015" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "2" => {
-              start: { day: "06", month: "04", year: "2015" },
-              stop: { day: "", month: "", year: "" },
-            },
-         },
+          is_part_year_claim: "no"
        ).benefits_claimed_amount.round(2)).to eq(2549.3)
       end
 
@@ -850,14 +772,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: "1",
-          is_part_year_claim: "yes",
-          part_year_children_count: "1",
-          starting_children: {
-            "0" => {
-              start: { year: "2015", month: "04", day: "06" },
-              stop: { year: "2016", month: "04", day: "05" },
-            },
-          },
+          is_part_year_claim: "no"
         ).benefits_claimed_amount.round(2)).to eq(1097.1)
       end
 
@@ -866,13 +781,9 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 2,
           is_part_year_claim: "yes",
-          part_year_children_count: "2",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
-              start: { day: "06", month: "04", year: "2015" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
               start: { day: "06", month: "04", year: "2015" },
               stop: { day: "06", month: "11", year: "2016" },
             },
@@ -902,22 +813,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 3,
-          is_part_year_claim: "yes",
-          part_year_children_count: "3",
-          starting_children: {
-            "0" => {
-              start: { day: "06", month: "04", year: "2016" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
-              start: { day: "06", month: "04", year: "2016" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "2" => {
-              start: { day: "06", month: "04", year: "2016" },
-              stop: { day: "", month: "", year: "" },
-            },
-         },
+          is_part_year_claim: "no"
        ).benefits_claimed_amount.round(2)).to eq(2501.2)
       end
 
@@ -925,14 +821,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: "1",
-          is_part_year_claim: "yes",
-          part_year_children_count: "1",
-          starting_children: {
-            "0" => {
-              start: { year: "2016", month: "04", day: "06" },
-              stop: { year: "2017", month: "04", day: "05" },
-            },
-          },
+          is_part_year_claim: "no"
         ).benefits_claimed_amount.round(2)).to eq(1076.4)
       end
 
@@ -941,13 +830,9 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: 2,
           is_part_year_claim: "yes",
-          part_year_children_count: "2",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
-              start: { day: "06", month: "04", year: "2016" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
               start: { day: "06", month: "04", year: "2016" },
               stop: { day: "06", month: "10", year: "2016" },
             },
@@ -997,6 +882,25 @@ describe ChildBenefitTaxCalculator, type: :model do
         )
 
         expect(calc.child_benefit_end_date).to eq(Date.parse("05 April 2016"))
+      end
+
+      it "should correctly calculate the benefit amount for multiple full year and part year children" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2016",
+          children_count: 4,
+          is_part_year_claim: "yes",
+          part_year_children_count: "2",
+          starting_children: {
+            "0" => {
+              start: { day: "01", month: "06", year: "2016" },
+              stop: { day: "01", month: "09", year: "2016" }
+            },
+            "1" => {
+              start: { day: "01", month: "01", year: "2017" },
+              stop: { day: "01", month: "04", year: "2017" }
+            }
+          }
+        ).benefits_claimed_amount.round(2)).to eq(2145)
       end
     end
   end

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -64,6 +64,27 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc.valid?
       expect(@calc.errors).to have_key(:tax_year)
     end
+    it "should contain errors if number of children is less than those being part claimed" do
+      @calc = ChildBenefitTaxCalculator.new(
+        year: "2013",
+        children_count: "1",
+        part_year_children_count: "2",
+        is_part_year_claim: "yes",
+        starting_children: {
+          "0" => {
+            start: { year: "2013", month: "01", day: "01" },
+            stop: { year: "2014", month: "01", day: "01" },
+          },
+          "1" => {
+            start: { year: "2013", month: "03", day: "01" },
+            stop: { year: "2014", month: "03", day: "01" },
+          },
+        },
+      )
+      @calc.valid?
+
+      expect(@calc.errors).to have_key(:part_year_children_count)
+    end
     it "should validate dates provided for children" do
       expect(@calc.starting_children.first.errors.has_key?(:start_date)).to eq(true)
 

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -53,7 +53,7 @@ describe ChildBenefitTaxCalculator, type: :model do
 
   describe "input validation" do
     before(:each) do
-      @calc = ChildBenefitTaxCalculator.new(children_count: "1", is_part_year_claim: "no")
+      @calc = ChildBenefitTaxCalculator.new(children_count: "1", is_part_year_claim: "yes")
       @calc.valid?
     end
     it "should contain errors for year if none is given" do
@@ -66,6 +66,7 @@ describe ChildBenefitTaxCalculator, type: :model do
     end
     it "should validate dates provided for children" do
       expect(@calc.starting_children.first.errors.has_key?(:start_date)).to eq(true)
+
       @calc.starting_children << StartingChild.new(
         start: { year: "2012", month: "02", day: "01" },
         stop: { year: "2012", month: "01", day: "01" },

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -139,7 +139,6 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1", is_part_year_claim: "yes")
         calc.valid?
         expect(calc.errors).to be_empty
-        #puts calc.starting_children.first.errors.full_messages
         expect(calc.has_errors?).to eq(true)
       end
       it "should be false if the tax year and starting date are valid" do

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -16,6 +16,7 @@ describe ChildBenefitTaxCalculator, type: :model do
     expect(ChildBenefitTaxCalculator.new(
       year: "2012", children_count: "1",
       is_part_year_claim: "yes",
+      part_year_children_count: "1",
       starting_children: { "0" => { start: { year: "2011", month: "01", day: "01" } } },
     ).can_calculate?).to eq(true)
   end
@@ -100,6 +101,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -116,6 +118,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -132,6 +135,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: "3",
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -157,7 +161,12 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(@calc.errors.size).to eq(1)
       end
       it "should be true if any starting children have errors" do
-        calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1", is_part_year_claim: "yes")
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2012",
+          children_count: "1",
+          is_part_year_claim: "yes",
+          part_year_children_count: "1"
+        )
         calc.valid?
         expect(calc.errors).to be_empty
         expect(calc.has_errors?).to eq(true)
@@ -167,6 +176,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2012",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2012", month: "01", day: "07" } },
           },
@@ -190,6 +200,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(children_count: "1",
             year: 2012,
             is_part_year_claim: "yes",
+            part_year_children_count: "1",
             starting_children: {
               "0" => { start: { year: "2012", month: "01", day: "07" } },
             }
@@ -200,12 +211,38 @@ describe ChildBenefitTaxCalculator, type: :model do
     end
   end
 
+  describe "full year and part year children" do
+    it "should not contain errors if valid part year and full year children" do
+      calc = ChildBenefitTaxCalculator.new(
+        children_count: "3",
+        year: "2016",
+        is_part_year_claim: "yes",
+        part_year_children_count: "2",
+        starting_children: {
+          "0" => {
+            start: { year: "2016", month: "06", day: "13" },
+            stop: { year: "2016", month: "06", day: "19" },
+          },
+          "1" => {
+            start: { year: "2016", month: "06", day: "20" },
+            stop: { year: "2016", month: "06", day: "26" },
+          }
+        }
+      )
+      calc.valid?
+      calc.starting_children.each do |child|
+        expect(child.errors).to be_empty
+      end
+    end
+  end
+
   describe "calculating benefits received" do
     it "should give the total amount of benefits received for a full tax year 2012" do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "02", day: "01" },
@@ -219,6 +256,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2013", month: "04", day: "06" },
@@ -232,6 +270,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -245,6 +284,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: "2",
         is_part_year_claim: "yes",
+        part_year_children_count: "2",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -382,6 +422,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "49999",
           is_part_year_claim: "yes",
           children_count: 1,
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -393,6 +434,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "50100",
           is_part_year_claim: "yes",
           children_count: 1,
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -405,7 +447,9 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "calculates the correct amount owed for % charge of 100" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "60001",
+          children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -418,6 +462,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "59900",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -430,6 +475,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "54000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -444,6 +490,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "60001",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -456,6 +503,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "59900",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -468,6 +516,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "54000",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2011", month: "01", day: "01" },
@@ -488,6 +537,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "61000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "03", day: "01" },
@@ -504,6 +554,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "61000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2012", month: "05", day: "01" },
@@ -520,6 +571,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "61000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "02", day: "01" },
@@ -539,6 +591,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "61000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "02", day: "22" },
@@ -559,6 +612,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: 3,
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
@@ -580,6 +634,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "56000",
         year: "2012", children_count: 3,
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
@@ -603,6 +658,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: 1,
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { day: "14", month: "01", year: "2013" },
@@ -617,6 +673,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: 3,
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -641,6 +698,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: 3,
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -665,6 +723,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: 1,
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { day: "01", month: "07", year: "2013" },
@@ -682,6 +741,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: 3,
           is_part_year_claim: "yes",
+          part_year_children_count: "3",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -704,6 +764,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "04", day: "06" },
@@ -718,6 +779,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: 2,
           is_part_year_claim: "yes",
+          part_year_children_count: "2",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -736,6 +798,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -753,6 +816,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 3,
           is_part_year_claim: "yes",
+          part_year_children_count: "3",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -775,6 +839,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2015", month: "04", day: "06" },
@@ -789,6 +854,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 2,
           is_part_year_claim: "yes",
+          part_year_children_count: "2",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -807,6 +873,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -824,6 +891,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: 3,
           is_part_year_claim: "yes",
+          part_year_children_count: "3",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -846,6 +914,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2016", month: "04", day: "06" },
@@ -860,6 +929,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: 2,
           is_part_year_claim: "yes",
+          part_year_children_count: "2",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -878,6 +948,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -904,6 +975,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -211,6 +211,18 @@ describe ChildBenefitTaxCalculator, type: :model do
     end
   end
 
+  describe "full year children only" do
+    it "should be able to calculate the child benefit amount" do
+      calc = ChildBenefitTaxCalculator.new(
+        children_count: 1,
+        year: "2015",
+        is_part_year_claim: "no",
+        starting_children: {}
+      )
+      expect(calc.can_calculate?).to eq(true)
+    end
+  end
+
   describe "full year and part year children" do
     it "should not contain errors if valid part year and full year children" do
       calc = ChildBenefitTaxCalculator.new(


### PR DESCRIPTION
Trello card: https://trello.com/c/HXEm9Bkk/173-child-benefit-tax-calculator-part-year-some-children-add-logic-for-answering-yes

## Factcheck

Not applicable. This PR is part of a larger set of changes that will be factchecked as a whole.

## Expected Changes

[URL on GOV.UK](https://www.gov.uk/child-benefit-tax-calculator/main)
* Add a new question that asks how many children are only being claimed for part of the tax year.
* Use the start and end dates populated by the user to determine how many weeks to calculate child benefit for for part year children.
* Use the tax year start and end dates to calculate the child benefit for children being claimed for part of the year.

### Before

![screen shot 2016-06-29 at 13 16 12](https://cloud.githubusercontent.com/assets/5793815/16451550/b0b906f0-3dfb-11e6-9c1d-e61bb688083a.png)

### After

![screen shot 2016-06-29 at 13 18 18](https://cloud.githubusercontent.com/assets/5793815/16451611/fda6afbc-3dfb-11e6-9fbd-74cdc3f8633c.png)
