### PR TITLE
Update advice about which dates to enter

### DIFF
--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -50,7 +50,7 @@
             <% end -%>
           </div>
         </fieldset>
-        
+
         <fieldset id="is-part-year-claim">
           <%= step(3, "Choose a tax claim duration:") %>
           <p>Are you claiming for a part of the tax year for any of your children?</p>
@@ -110,7 +110,7 @@
 
         <h2>Enter the Child Benefit start and stop dates:</h2>
         <ul>
-          <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
+          <li>the start date is called an ‘effective date’ - you can find it on your Child Benefit award notice</li>
           <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
         </ul>
         <%= render "starting_children" %>


### PR DESCRIPTION
The number of weeks included in the child benefit calculation has
changed. We are assuming the start date is the effective date of the
child benefit, i.e. the date the child benefit starts. If the effective
start date is a Monday, we are including it in the calculation.

The advice to users has been updated to reflect the changes.