### PR TITLE
Feature part year and effective date calculation

### DIFF
--- a/app/assets/javascripts/child-benefit-tax-calculator.js
+++ b/app/assets/javascripts/child-benefit-tax-calculator.js
@@ -1,4 +1,4 @@
-(function () {
+(function() {
   "use strict";
 
   var root = this,
@@ -7,17 +7,41 @@
 
   var calculator = {
     childrenCountInput: $("#children_count"),
-    childrenContainer: $("fieldset#children"),
-
-    setEventHandlers: function () {
-      calculator.childrenCountInput.on('change', calculator.updateChildrenFields);
+    childrenContainerTemplate: $("div#children-template"),
+    taxClaimContainer: $("fieldset#is-part-year-claim"),
+    taxClaimDurationInputs: $("input[id^='is_part_year_claim_']"),
+    childrenContainer: function() {
+      return $("div#children");
     },
-    updateChildrenFields: function () {
+    setEventHandlers: function() {
+      calculator.childrenCountInput.on('change', calculator.updateChildrenFields);
+      calculator.taxClaimDurationInputs.on('change', calculator.triggerChildrenFieldsEvent);
+      calculator.setUpForm();
+    },
+    setUpForm: function(){
+      var choosenTaxClaim = calculator.taxClaimDurationInputs.filter(":checked").val();
+      calculator.toggleChildrenFields(choosenTaxClaim);
+    },
+    triggerChildrenFieldsEvent: function(event){
+      calculator.toggleChildrenFields($(event.currentTarget).val());
+    },
+    toggleChildrenFields: function(choosen){
+      if (choosen == "yes") {
+        if (calculator.childrenContainer().length == 0) {
+          var childrenTag = calculator.childrenContainerTemplate.clone();
+          calculator.taxClaimContainer.append(childrenTag);
+          childrenTag.attr("id", "children").show();
+          calculator.updateChildrenFields();
+        }
+      } else {
+        calculator.childrenContainer().remove();
+      }
+    },
+    updateChildrenFields: function() {
       var numStartingChildren = calculator.childrenCountInput.val(),
-        childFields = calculator.childrenContainer.find('> div.child'),
+        childFields = calculator.childrenContainer().find("> div.child"),
         numChildFields = childFields.size(),
         numNewFields = numStartingChildren - numChildFields;
-
       if (numStartingChildren < 1 || numStartingChildren > 10) {
         return false;
       }
@@ -31,7 +55,7 @@
         }
       }
     },
-    appendChildField: function (index) {
+    appendChildField: function(index) {
       var newChild = calculator.childFieldToClone().clone();
 
       newChild.find('.child-number').text(index+1);
@@ -44,14 +68,14 @@
         $(this).attr('for', calculator.replaceIndex(index, $(this).attr('for')));
       });
 
-      newChild.appendTo(calculator.childrenContainer);
+      newChild.appendTo(calculator.childrenContainer());
     },
-    childFieldToClone: function () {
+    childFieldToClone: function() {
       // Always clone the first field so that we don't have to guess
       // the index (it will always be zero)
-      return calculator.childrenContainer.find("> div.child").first();
+      return calculator.childrenContainer().find("> div.child").first();
     },
-    replaceIndex: function (index, str) {
+    replaceIndex: function(index, str) {
       return str.replace("0", index);
     }
   };

--- a/app/assets/javascripts/child-benefit-tax-calculator.js
+++ b/app/assets/javascripts/child-benefit-tax-calculator.js
@@ -7,6 +7,9 @@
 
   var calculator = {
     childrenCountInput: $("#children_count"),
+    partYearChildrenCountInput: function(){
+      return $("div#children #part_year_children_count")
+    },
     childrenContainerTemplate: $("div#children-template"),
     taxClaimContainer: $("fieldset#is-part-year-claim"),
     taxClaimDurationInputs: $("input[id^='is_part_year_claim_']"),
@@ -14,7 +17,6 @@
       return $("div#children");
     },
     setEventHandlers: function() {
-      calculator.childrenCountInput.on('change', calculator.updateChildrenFields);
       calculator.taxClaimDurationInputs.on('change', calculator.triggerChildrenFieldsEvent);
       calculator.setUpForm();
     },
@@ -31,14 +33,16 @@
           var childrenTag = calculator.childrenContainerTemplate.clone();
           calculator.taxClaimContainer.append(childrenTag);
           childrenTag.attr("id", "children").show();
+          calculator.partYearChildrenCountInput().on('change', calculator.updateChildrenFields);
           calculator.updateChildrenFields();
         }
       } else {
+        calculator.partYearChildrenCountInput().off('change');
         calculator.childrenContainer().remove();
       }
     },
     updateChildrenFields: function() {
-      var numStartingChildren = calculator.childrenCountInput.val(),
+      var numStartingChildren = calculator.partYearChildrenCountInput().val(),
         childFields = calculator.childrenContainer().find("> div.child"),
         numChildFields = childFields.size(),
         numNewFields = numStartingChildren - numChildFields;

--- a/app/assets/stylesheets/calculators/child_benefit.scss
+++ b/app/assets/stylesheets/calculators/child_benefit.scss
@@ -104,6 +104,7 @@ li {
   // scss-lint:disable IdSelector
   #children {
     margin-bottom: 0;
+    float: left;
 
     h3 {
       @include bold-19;

--- a/app/controllers/child_benefit_tax_controller.rb
+++ b/app/controllers/child_benefit_tax_controller.rb
@@ -1,7 +1,7 @@
 class ChildBenefitTaxController < ApplicationController
   before_filter :setup_slimmer
 
-  CALC_PARAM_KEYS = [:adjusted_net_income, :children_count, :starting_children, :year, :results] +
+  CALC_PARAM_KEYS = [:adjusted_net_income, :children_count, :starting_children, :year, :results, :part_year_children_count] +
     AdjustedNetIncomeCalculator::PARAM_KEYS
 
   def landing

--- a/app/models/adjusted_net_income_calculator.rb
+++ b/app/models/adjusted_net_income_calculator.rb
@@ -2,7 +2,7 @@
 class AdjustedNetIncomeCalculator
   PARAM_KEYS = [:gross_income, :other_income, :pension_contributions_from_pay,
                 :retirement_annuities, :cycle_scheme, :childcare, :pensions, :property,
-                :non_employment_income, :gift_aid_donations, :outgoing_pension_contributions]
+                :non_employment_income, :gift_aid_donations, :outgoing_pension_contributions, :is_part_year_claim]
 
   def initialize(params)
     PARAM_KEYS.each do |key|

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -29,8 +29,8 @@ class ChildBenefitTaxCalculator
     @children_count = params[:children_count] ? params[:children_count].to_i : 1
     @part_year_children_count = params[:part_year_children_count] ? params[:part_year_children_count].to_i : 0
     @is_part_year_claim = params[:is_part_year_claim]
-    @starting_children = process_starting_children(params[:starting_children])
     @tax_year = params[:year].to_i
+    @starting_children = process_starting_children(params[:starting_children])
   end
 
   def self.valid_date_params?(params)
@@ -91,11 +91,15 @@ class ChildBenefitTaxCalculator
 
   def benefits_claimed_amount
     all_weeks_children = {}
+    full_year_children = @children_count - @part_year_children_count
     (child_benefit_start_date...child_benefit_end_date).each_slice(7) do |week|
       monday = monday_on_or_after(week.first)
       all_weeks_children[monday] = 0
       @starting_children.each do |child|
         all_weeks_children[monday] += 1 if eligible?(child, tax_year, monday)
+      end
+      full_year_children.times do
+        all_weeks_children[monday] += 1
       end
     end
     # calculate total for all weeks
@@ -112,8 +116,14 @@ class ChildBenefitTaxCalculator
 private
 
   def process_starting_children(children)
+    if selected_tax_year.present?
+      number_of_children = @part_year_children_count
+    else
+      number_of_children = @children_count
+    end
+
     [].tap do |ary|
-      @children_count.times do |n|
+      number_of_children.times do |n|
         if children && children[n.to_s] && valid_date_params?(children[n.to_s][:start])
           ary << StartingChild.new(children[n.to_s])
         else

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -37,8 +37,10 @@ class ChildBenefitTaxCalculator
     self.class.valid_date_params?(params)
   end
 
+  # Return the date of the Monday in the future that is closest to the date supplied.
+  # If the date supplied is a Monday, do not adjust it.
   def monday_on_or_after(date)
-    date + ((1 - date.wday) % 7)
+    date.monday? ? date : date.next_week(:monday)
   end
 
   def nothing_owed?
@@ -114,8 +116,10 @@ private
   end
 
   def eligible?(child, tax_year, week_start_date)
+    adjusted_start_date = monday_on_or_after(child.start_date)
+
     eligible_for_tax_year?(child, tax_year) &&
-      days_include_week?(child.adjusted_start_date, child.benefits_end, week_start_date)
+      days_include_week?(adjusted_start_date, child.benefits_end, week_start_date)
   end
 
   def eligible_for_tax_year?(child, tax_year)

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -181,7 +181,7 @@ private
   end
 
   def valid_child_dates
-    @starting_children.each(&:valid?)
+    is_part_year_claim == 'yes' && @starting_children.each(&:valid?)
   end
 
   def tax_year_contains_at_least_one_child

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -78,7 +78,7 @@ class ChildBenefitTaxCalculator
   end
 
   def can_calculate?
-    valid? && !has_errors? && @starting_children.any?
+    valid? && !has_errors?
   end
 
   def selected_tax_year

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -20,12 +20,14 @@ class ChildBenefitTaxCalculator
   validate :valid_child_dates
   validates_presence_of :is_part_year_claim, message: "select part year tax claim"
   validates_inclusion_of :tax_year, in: TAX_YEARS.keys.map(&:to_i), message: "select a tax year"
+  validate :valid_number_of_children
   validate :tax_year_contains_at_least_one_child
 
   def initialize(params = {})
     @adjusted_net_income_calculator = AdjustedNetIncomeCalculator.new(params)
     @adjusted_net_income = calculate_adjusted_net_income(params[:adjusted_net_income])
     @children_count = params[:children_count] ? params[:children_count].to_i : 1
+    @part_year_children_count = params[:part_year_children_count] ? params[:part_year_children_count].to_i : 0
     @is_part_year_claim = params[:is_part_year_claim]
     @starting_children = process_starting_children(params[:starting_children])
     @tax_year = params[:year].to_i
@@ -182,6 +184,12 @@ private
 
   def valid_child_dates
     is_part_year_claim == 'yes' && @starting_children.each(&:valid?)
+  end
+
+  def valid_number_of_children
+    if @is_part_year_claim == 'yes' && (@children_count < @part_year_children_count)
+      errors.add(:part_year_children_count, "The number of children being claimed cannot exceed the total number of children being claimed for.")
+    end
   end
 
   def tax_year_contains_at_least_one_child

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -4,7 +4,7 @@ class ChildBenefitTaxCalculator
   include ActiveModel::Validations
 
   attr_reader :adjusted_net_income_calculator, :adjusted_net_income, :children_count,
-    :starting_children, :tax_year, :is_part_year_claim
+    :starting_children, :tax_year, :is_part_year_claim, :part_year_children_count
 
   NET_INCOME_THRESHOLD = 50000
   TAX_COMMENCEMENT_DATE = Date.parse('7 Jan 2013')

--- a/app/models/starting_child.rb
+++ b/app/models/starting_child.rb
@@ -20,21 +20,6 @@ class StartingChild
     @end_date ? @end_date : tax_years[tax_years.keys.sort.last].last
   end
 
-  # Return the date of the Monday in the future that is closest to the start_date.
-  # If the start_date is a Monday, use the start_date.
-  def adjusted_start_date
-    return nil if start_date.nil?
-
-    if start_date.wday < 1
-      start_date + 1.day
-    elsif start_date.wday > 1
-      number_of_days_til_next_monday = ((1 - start_date.wday) + 7)
-      start_date + number_of_days_til_next_monday
-    else
-      start_date
-    end
-  end
-
 private
 
   def valid_dates

--- a/app/models/starting_child.rb
+++ b/app/models/starting_child.rb
@@ -20,10 +20,19 @@ class StartingChild
     @end_date ? @end_date : tax_years[tax_years.keys.sort.last].last
   end
 
-  # Return the next Monday if start_date is not nil.
+  # Return the date of the Monday in the future that is closest to the start_date.
+  # If the start_date is a Monday, use the start_date.
   def adjusted_start_date
     return nil if start_date.nil?
-    start_date + (start_date.wday < 1 ? 1 : (1 - start_date.wday) + 7)
+
+    if start_date.wday < 1
+      start_date + 1.day
+    elsif start_date.wday > 1
+      number_of_days_til_next_monday = ((1 - start_date.wday) + 7)
+      start_date + number_of_days_til_next_monday
+    else
+      start_date
+    end
   end
 
 private

--- a/app/views/child_benefit_tax/_starting_children.html.erb
+++ b/app/views/child_benefit_tax/_starting_children.html.erb
@@ -1,9 +1,16 @@
-<% @calculator.starting_children.each_with_index do |child, index| -%>
-  <div class="child<% if child.errors.any? %> validation-error<% end -%>">
-    <% child.errors.each do |key, message| -%>
-      <p><%= message %></p>
-    <% end -%>
-    <h3>Child <span class="child-number"><%= index + 1 %></span></h3>
-    <%= render "starting_child", :index => index, :child => child %>
+<% if @calculator.starting_children.count == 0 %>
+  <div class="child">
+    <h3>Child <span class="child-number"> 1 </span></h3>
+    <%= render "starting_child", index: 0, child: StartingChild.new  %>
   </div>
-<% end -%>
+<% else %>
+  <% @calculator.starting_children.each_with_index do |child, index| -%>
+    <div class="child<% if child.errors.any? %> validation-error<% end -%>">
+      <% child.errors.each do |key, message| -%>
+        <p><%= message %></p>
+      <% end -%>
+      <h3>Child <span class="child-number"><%= index + 1 %></span></h3>
+      <%= render "starting_child", :index => index, :child => child %>
+    </div>
+  <% end -%>
+<% end %>

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -101,6 +101,12 @@
         <%= submit_tag "Calculate", :name => "results", :class => "button" %>
       <% end %>
       <div id="children-template" style="display:none">
+        <div class="part-year-children-count">
+          <h2>Enter the number of children only being claimed for part of the year:<h2>
+          <label for="part_year_children_count" class="visuallyhidden">Number of part year children</label>
+          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}) %>
+        </div>
+
         <h2>Enter the Child Benefit start and stop dates:</h2>
         <ul>
           <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -104,7 +104,8 @@
         <div class="part-year-children-count">
           <h2>Enter the number of children only being claimed for part of the year:<h2>
           <label for="part_year_children_count" class="visuallyhidden">Number of part year children</label>
-          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}) %>
+          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}, @calculator.children_count) %>
+          <%= submit_tag "Update Children", :name => "children", :class => "button update-button" %>
         </div>
 
         <h2>Enter the Child Benefit start and stop dates:</h2>

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -50,14 +50,21 @@
             <% end -%>
           </div>
         </fieldset>
-
-        <fieldset id="children">
-          <%= step(3, "Enter the Child Benefit start and stop dates:") %>
-          <ul>
-            <li>the start date is called an ‘effective date’ - you can find it on your Child Benefit award notice</li>
-            <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
-          </ul>
-          <%= render "starting_children" %>
+        
+        <fieldset id="is-part-year-claim">
+          <%= step(3, "Choose a tax claim duration:") %>
+          <p>Are you claiming for a part of the tax year for any of your children?</p>
+          <div class="is-part-year-claim<% if @calculator.errors.has_key?(:is_part_year_claim) %> validation-error<% end %>">
+            <% @calculator.errors[:is_part_year_claim].each do |message| %>
+              <p><%= message %></p>
+            <% end -%>
+            <% ["yes", "no"].each do |option| -%>
+              <label for="is_part_year_claim_<%= option %>" class="selectable">
+                <%= radio_button_tag "is_part_year_claim", option, (@calculator.is_part_year_claim == option) %>
+                <%= option.capitalize %>
+              </label>
+            <% end -%>
+          </div>
         </fieldset>
 
         <fieldset id="adjusted_income">
@@ -93,6 +100,14 @@
 
         <%= submit_tag "Calculate", :name => "results", :class => "button" %>
       <% end %>
+      <div id="children-template" style="display:none">
+        <h2>Enter the Child Benefit start and stop dates:</h2>
+        <ul>
+          <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
+          <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
+        </ul>
+        <%= render "starting_children" %>
+      </div>
 
       <% if can_haz_results? -%>
       <div class="results">

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -54,7 +54,7 @@
         <fieldset id="children">
           <%= step(3, "Enter the Child Benefit start and stop dates:") %>
           <ul>
-            <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
+            <li>the start date is called an ‘effective date’ - you can find it on your Child Benefit award notice</li>
             <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
           </ul>
           <%= render "starting_children" %>

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -104,7 +104,7 @@
         <div class="part-year-children-count">
           <h2>Enter the number of children only being claimed for part of the year:<h2>
           <label for="part_year_children_count" class="visuallyhidden">Number of part year children</label>
-          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}, @calculator.children_count) %>
+          <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}, @calculator.part_year_children_count) %>
           <%= submit_tag "Update Children", :name => "children", :class => "button update-button" %>
         </div>
 

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -50,7 +50,7 @@
             <% end -%>
           </div>
         </fieldset>
-        
+
         <fieldset id="is-part-year-claim">
           <%= step(3, "Choose a tax claim duration:") %>
           <p>Are you claiming for a part of the tax year for any of your children?</p>
@@ -110,7 +110,7 @@
 
         <h2>Enter the Child Benefit start and stop dates:</h2>
         <ul>
-          <li>the start date is usually when you have a baby, adopt or move in with a new partner and their children</li>
+          <li>the start date is called an ‘effective date’ - you can find it on your Child Benefit award notice</li>
           <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
         </ul>
         <%= render "starting_children" %>

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -108,6 +108,14 @@ feature "Child Benefit Tax Calculator", js: true do
           end
         end
       end
+      it "should ask how many children are being claimed for a part year" do
+        choose "Yes"
+        within "#is-part-year-claim" do
+          within "#children" do
+            expect(page).to have_select("part_year_children_count")
+          end
+        end
+      end
     end
   end
 

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -589,6 +589,40 @@ feature "Child Benefit Tax Calculator", js: true do
     end # ANI below threshold
   end
 
+  describe "displaying results for full year children only" do
+    before(:each) do
+      visit "/child-benefit-tax-calculator"
+      click_on "Start now"
+    end
+
+    context "one child" do
+      it "should correctly display the amount for one child" do
+        choose "year_2015"
+        choose "No"
+
+        click_button "Calculate"
+
+        within ".results" do
+          expect(page).to have_content("£1,097.10")
+        end
+      end
+    end
+
+    context "two children" do
+      it "should correctly display the amount for two children" do
+        select "2", from: "children_count"
+        choose "year_2015"
+        choose "No"
+
+        click_button "Calculate"
+
+        within ".results" do
+          expect(page).to have_content("£1,823.20")
+        end
+      end
+    end
+  end
+
   describe "child benefit week runs Monday to Sunday" do
     before(:each) do
       visit "/child-benefit-tax-calculator"

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -46,7 +46,8 @@ feature "Child Benefit Tax Calculator", js: true do
         click_on "Calculate"
         within ".validation-summary" do
           expect(page).to have_content("select a tax year")
-          expect(page).to have_content("enter the date Child Benefit started")
+          expect(page).to have_content("select part year tax claim")
+          expect(page).to have_no_content("enter the date Child Benefit started")
         end
 
         within "#tax-year" do
@@ -68,7 +69,7 @@ feature "Child Benefit Tax Calculator", js: true do
         click_on "Calculate"
         within ".validation-summary" do
           expect(page).to have_content("select a tax year")
-          expect(page).to have_content("enter the date Child Benefit started")
+          expect(page).to have_no_content("enter the date Child Benefit started")
         end
 
         within "#tax-year" do
@@ -108,11 +109,30 @@ feature "Child Benefit Tax Calculator", js: true do
           end
         end
       end
+
       it "should ask how many children are being claimed for a part year" do
         choose "Yes"
         within "#is-part-year-claim" do
           within "#children" do
             expect(page).to have_select("part_year_children_count")
+          end
+        end
+      end
+      it "should show two date selectors if two part year children are selected" do
+        choose "Yes"
+        select "2", from: "part_year_children_count"
+        click_button "Update Children"
+
+        within "#is-part-year-claim" do
+          within "#children" do
+            expect(page).to have_select("part_year_children_count", selected: "2")
+
+            expect(page).to have_css("#starting_children_0_start_year")
+            expect(page).to have_css("#starting_children_0_start_month")
+            expect(page).to have_css("#starting_children_0_start_day")
+            expect(page).to have_css("#starting_children_1_start_year")
+            expect(page).to have_css("#starting_children_1_start_month")
+            expect(page).to have_css("#starting_children_1_start_day")
           end
         end
       end
@@ -125,7 +145,7 @@ feature "Child Benefit Tax Calculator", js: true do
     click_on "Start now"
     choose "Yes"
 
-    select "2", from: "children_count"
+    select "2", from: "part_year_children_count"
 
     select "2012", from: "starting_children[0][start][year]"
     select "February", from: "starting_children[0][start][month]"
@@ -166,8 +186,8 @@ feature "Child Benefit Tax Calculator", js: true do
     click_on "Start now"
     choose "Yes"
 
-    select "1", from: "children_count"
-    click_button "Update"
+    select "1", from: "part_year_children_count"
+    click_button "Update Children"
 
     page.find("#starting_children_0_start_year").select("2011")
     page.find("#starting_children_0_start_month").select("January")
@@ -195,12 +215,12 @@ feature "Child Benefit Tax Calculator", js: true do
       visit "/child-benefit-tax-calculator"
       click_on "Start now"
       choose "Yes"
-      select "2", from: "children_count"
-      click_button "Update"
+      select "2", from: "part_year_children_count"
+      click_button "Update Children"
     end
 
     it "should show the required number of date inputs" do
-      expect(page).to have_select("children_count", selected: "2")
+      expect(page).to have_select("part_year_children_count", selected: "2")
 
       expect(page).to have_css("#starting_children_0_start_year")
       expect(page).to have_css("#starting_children_0_start_month")
@@ -213,11 +233,11 @@ feature "Child Benefit Tax Calculator", js: true do
       page.find("#starting_children_0_start_month").select("January")
       page.find("#starting_children_0_start_day").select("1")
 
-      select "3", from: "children_count"
+      select "3", from: "part_year_children_count"
 
-      click_button "Update"
+      click_button "Update Children"
 
-      expect(page).to have_select("children_count", selected: "3")
+      expect(page).to have_select("part_year_children_count", selected: "3")
 
       expect(page).to have_select("starting_children_0_start_year", selected: "2011")
       expect(page).to have_select("starting_children_0_start_month", selected: "January")
@@ -231,9 +251,9 @@ feature "Child Benefit Tax Calculator", js: true do
       select "January", from: "starting_children_1_start_month"
       select "7", from: "starting_children_1_start_day"
 
-      select "1", from: "children_count"
+      select "1", from: "part_year_children_count"
 
-      click_button "Update"
+      click_button "Update Children"
 
       expect(page).to have_no_css("#starting_children_1_start_year")
       expect(page).to have_no_css("#starting_children_1_start_month")
@@ -241,7 +261,11 @@ feature "Child Benefit Tax Calculator", js: true do
     end
 
     it "should show the required number of date inputs without reloading the page" do
-      expect(page).to have_select("children_count", selected: "2")
+      choose "Yes"
+      select "2", from: "part_year_children_count"
+      click_button "Update Children"
+
+      expect(page).to have_select("part_year_children_count", selected: "2")
 
       expect(page).to have_css("#starting_children_0_start_year")
       expect(page).to have_css("#starting_children_0_start_month")
@@ -254,7 +278,7 @@ feature "Child Benefit Tax Calculator", js: true do
       page.find("#starting_children_0_start_month").select("January")
       page.find("#starting_children_0_start_day").select("1")
 
-      select "3", from: "children_count"
+      select "3", from: "part_year_children_count"
 
       expect(page).to have_select("starting_children_0_start_year", selected: "2011")
       expect(page).to have_select("starting_children_0_start_month", selected: "January")
@@ -268,7 +292,7 @@ feature "Child Benefit Tax Calculator", js: true do
       select "January", from: "starting_children_1_start_month"
       select "7", from: "starting_children_1_start_day"
 
-      select "1", from: "children_count"
+      select "1", from: "part_year_children_count"
 
       expect(page).to have_no_css("#starting_children_1_start_year")
       expect(page).to have_no_css("#starting_children_1_start_month")
@@ -281,6 +305,10 @@ feature "Child Benefit Tax Calculator", js: true do
       end
 
       it "calculates the overall benefits received for both children" do
+        choose "Yes"
+        select "2", from: "part_year_children_count"
+        click_button "Update Children"
+
         select "2011", from: "starting_children_0_start_year"
         select "January", from: "starting_children_0_start_month"
         select "1", from: "starting_children_0_start_day"
@@ -288,6 +316,7 @@ feature "Child Benefit Tax Calculator", js: true do
         select "2012", from: "starting_children_1_start_year"
         select "February", from: "starting_children_1_start_month"
         select "5", from: "starting_children_1_start_day"
+
         choose "year_2012"
 
         click_button "Calculate"

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -305,6 +305,7 @@ feature "Child Benefit Tax Calculator", js: true do
       end
 
       it "calculates the overall benefits received for both children" do
+        select "2", from: "children_count"
         choose "Yes"
         select "2", from: "part_year_children_count"
         click_button "Update Children"

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -253,28 +253,14 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
-        is_part_year_claim: "yes",
-        part_year_children_count: "1",
-        starting_children: {
-          "0" => {
-            start: { year: "2011", month: "02", day: "01" },
-            stop: { year: "2013", month: "05", day: "01" },
-          },
-        },
+        is_part_year_claim: "no"
       ).benefits_claimed_amount.round(2)).to eq(263.9)
     end
     it "should give the total amount of benefits received for a full tax year 2013" do
       expect(ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
-        is_part_year_claim: "yes",
-        part_year_children_count: "1",
-        starting_children: {
-          "0" => {
-            start: { year: "2013", month: "04", day: "06" },
-            stop: { year: "2014", month: "04", day: "05" },
-          },
-        },
+        is_part_year_claim: "no"
       ).benefits_claimed_amount.round(2)).to eq(1055.6)
     end
     it "should give the total amount of benefits received for a partial tax year" do
@@ -684,22 +670,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "52000",
         year: "2013",
         children_count: 3,
-        is_part_year_claim: "yes",
-        part_year_children_count: "3",
-        starting_children: {
-          "0" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-          "1" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-          "2" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-        },
+        is_part_year_claim: "no"
       )
       expect(calc.benefits_claimed_amount.round(2)).to eq(2449.20)
       expect(calc.tax_estimate.round(2)).to eq(489)
@@ -710,17 +681,9 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: 3,
         is_part_year_claim: "yes",
-        part_year_children_count: "3",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-          "1" => {
-            start: { day: "06", month: "04", year: "2013" },
-            stop: { day: "", month: "", year: "" },
-          },
-          "2" => {
             start: { day: "06", month: "04", year: "2013" },
             stop: { day: "14", month: "06", year: "2013" },
           },
@@ -752,22 +715,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 3,
-          is_part_year_claim: "yes",
-          part_year_children_count: "3",
-          starting_children: {
-            "0" => {
-              start: { day: "06", month: "04", year: "2014" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
-              start: { day: "06", month: "04", year: "2014" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "2" => {
-              start: { day: "06", month: "04", year: "2014" },
-              stop: { day: "", month: "", year: "" },
-            },
-         },
+          is_part_year_claim: "no"
        ).benefits_claimed_amount.round(2)).to eq(2475.2)
       end
 
@@ -775,14 +723,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: "1",
-          is_part_year_claim: "yes",
-          part_year_children_count: "1",
-          starting_children: {
-            "0" => {
-              start: { year: "2014", month: "04", day: "06" },
-              stop: { year: "2015", month: "04", day: "05" },
-            },
-          },
+          is_part_year_claim: "no"
         ).benefits_claimed_amount.round(2)).to eq(1066.0)
       end
 
@@ -791,13 +732,9 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: 2,
           is_part_year_claim: "yes",
-          part_year_children_count: "2",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
-              start: { day: "06", month: "04", year: "2014" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
               start: { day: "06", month: "04", year: "2014" },
               stop: { day: "06", month: "11", year: "2014" },
             },
@@ -827,22 +764,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 3,
-          is_part_year_claim: "yes",
-          part_year_children_count: "3",
-          starting_children: {
-            "0" => {
-              start: { day: "06", month: "04", year: "2015" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
-              start: { day: "06", month: "04", year: "2015" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "2" => {
-              start: { day: "06", month: "04", year: "2015" },
-              stop: { day: "", month: "", year: "" },
-            },
-         },
+          is_part_year_claim: "no"
        ).benefits_claimed_amount.round(2)).to eq(2549.3)
       end
 
@@ -850,14 +772,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: "1",
-          is_part_year_claim: "yes",
-          part_year_children_count: "1",
-          starting_children: {
-            "0" => {
-              start: { year: "2015", month: "04", day: "06" },
-              stop: { year: "2016", month: "04", day: "05" },
-            },
-          },
+          is_part_year_claim: "no"
         ).benefits_claimed_amount.round(2)).to eq(1097.1)
       end
 
@@ -866,13 +781,9 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 2,
           is_part_year_claim: "yes",
-          part_year_children_count: "2",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
-              start: { day: "06", month: "04", year: "2015" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
               start: { day: "06", month: "04", year: "2015" },
               stop: { day: "06", month: "11", year: "2016" },
             },
@@ -902,22 +813,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 3,
-          is_part_year_claim: "yes",
-          part_year_children_count: "3",
-          starting_children: {
-            "0" => {
-              start: { day: "06", month: "04", year: "2016" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
-              start: { day: "06", month: "04", year: "2016" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "2" => {
-              start: { day: "06", month: "04", year: "2016" },
-              stop: { day: "", month: "", year: "" },
-            },
-         },
+          is_part_year_claim: "no"
        ).benefits_claimed_amount.round(2)).to eq(2501.2)
       end
 
@@ -925,14 +821,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: "1",
-          is_part_year_claim: "yes",
-          part_year_children_count: "1",
-          starting_children: {
-            "0" => {
-              start: { year: "2016", month: "04", day: "06" },
-              stop: { year: "2017", month: "04", day: "05" },
-            },
-          },
+          is_part_year_claim: "no"
         ).benefits_claimed_amount.round(2)).to eq(1076.4)
       end
 
@@ -941,13 +830,9 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: 2,
           is_part_year_claim: "yes",
-          part_year_children_count: "2",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
-              start: { day: "06", month: "04", year: "2016" },
-              stop: { day: "", month: "", year: "" },
-            },
-            "1" => {
               start: { day: "06", month: "04", year: "2016" },
               stop: { day: "06", month: "10", year: "2016" },
             },
@@ -997,6 +882,25 @@ describe ChildBenefitTaxCalculator, type: :model do
         )
 
         expect(calc.child_benefit_end_date).to eq(Date.parse("05 April 2016"))
+      end
+
+      it "should correctly calculate the benefit amount for multiple full year and part year children" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2016",
+          children_count: 4,
+          is_part_year_claim: "yes",
+          part_year_children_count: "2",
+          starting_children: {
+            "0" => {
+              start: { day: "01", month: "06", year: "2016" },
+              stop: { day: "01", month: "09", year: "2016" }
+            },
+            "1" => {
+              start: { day: "01", month: "01", year: "2017" },
+              stop: { day: "01", month: "04", year: "2017" }
+            }
+          }
+        ).benefits_claimed_amount.round(2)).to eq(2145)
       end
     end
   end

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -15,6 +15,7 @@ describe ChildBenefitTaxCalculator, type: :model do
   it "is valid if given enough detail" do
     expect(ChildBenefitTaxCalculator.new(
       year: "2012", children_count: "1",
+      is_part_year_claim: "yes",
       starting_children: { "0" => { start: { year: "2011", month: "01", day: "01" } } },
     ).can_calculate?).to eq(true)
   end
@@ -52,7 +53,7 @@ describe ChildBenefitTaxCalculator, type: :model do
 
   describe "input validation" do
     before(:each) do
-      @calc = ChildBenefitTaxCalculator.new(children_count: "1")
+      @calc = ChildBenefitTaxCalculator.new(children_count: "1", is_part_year_claim: "no")
       @calc.valid?
     end
     it "should contain errors for year if none is given" do
@@ -76,6 +77,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc = ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -91,6 +93,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc = ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -106,6 +109,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc = ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "3",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -131,7 +135,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(@calc.errors.size).to eq(1)
       end
       it "should be true if any starting children have errors" do
-        calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1")
+        calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1", is_part_year_claim: "yes")
         calc.valid?
         expect(calc.errors).to be_empty
         #puts calc.starting_children.first.errors.full_messages
@@ -141,6 +145,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2012",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2012", month: "01", day: "07" } },
           },
@@ -161,7 +166,13 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(calc.errors).to be_empty
       end
       it "should not contain errors if tax claim duration is set to yes" do
-        calc = ChildBenefitTaxCalculator.new(children_count: "1", year: 2012, is_part_year_claim: "yes")
+        calc = ChildBenefitTaxCalculator.new(children_count: "1",
+            year: 2012,
+            is_part_year_claim: "yes",
+            starting_children: {
+              "0" => { start: { year: "2012", month: "01", day: "07" } },
+            }
+          )
         calc.valid?
         expect(calc.errors).to be_empty
       end
@@ -173,6 +184,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "02", day: "01" },
@@ -185,6 +197,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2013",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2013", month: "04", day: "06" },
@@ -197,6 +210,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -209,6 +223,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "2",
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -230,6 +245,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         other_income: "0",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).adjusted_net_income).to eq(50099)
     end
 
@@ -247,6 +263,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         childcare: "£1500",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).adjusted_net_income).to eq(66950)
     end
 
@@ -265,6 +282,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         childcare: "£1500",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).adjusted_net_income).to eq(66950)
     end
   end
@@ -275,6 +293,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "50099",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(0.0)
     end
     it "should be 1.0 for an income of 50199" do
@@ -282,6 +301,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "50199",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(1.0)
     end
     it "should be 2.0 for an income of 50200" do
@@ -289,6 +309,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "50200",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(2.0)
     end
     it "should be 40.0 for an income of 54013" do
@@ -296,6 +317,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "54013",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(40.0)
     end
     it "should be 40.0 for an income of 54089" do
@@ -303,12 +325,14 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "54089",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(40.0)
     end
     it "should be 99.0 for an income of 59999" do
       expect(ChildBenefitTaxCalculator.new(
         adjusted_net_income: "59999",
         year: "2012",
+        is_part_year_claim: "no",
         children_count: 2,
       ).percent_tax_charge).to eq(99.0)
     end
@@ -317,6 +341,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "60000",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(100.0)
     end
     it "should be 100.0 for an income of 60001" do
@@ -324,6 +349,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "60001",
         year: "2012",
         children_count: 2,
+        is_part_year_claim: "no",
       ).percent_tax_charge).to eq(100.0)
     end
   end
@@ -333,6 +359,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "should be true for incomes under the threshold" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "49999",
+          is_part_year_claim: "yes",
           children_count: 1,
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
@@ -343,6 +370,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "should be true for incomes over the threshold" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "50100",
+          is_part_year_claim: "yes",
           children_count: 1,
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
@@ -356,6 +384,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "calculates the correct amount owed for % charge of 100" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "60001",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -367,6 +396,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "59900",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -378,6 +408,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "54000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -391,6 +422,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "60001",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -402,6 +434,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "59900",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -413,6 +446,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "54000",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2011", month: "01", day: "01" },
@@ -432,6 +466,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "03", day: "01" },
@@ -447,6 +482,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2012", month: "05", day: "01" },
@@ -462,6 +498,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "02", day: "01" },
@@ -480,6 +517,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           adjusted_net_income: "61000",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "02", day: "22" },
@@ -499,6 +537,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: 3,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
@@ -518,7 +557,9 @@ describe ChildBenefitTaxCalculator, type: :model do
     it "should calculate 3 children for 2012/2013 one child starting on 7 Jan 2013" do
       calc = ChildBenefitTaxCalculator.new(
         adjusted_net_income: "56000",
-        year: "2012", children_count: 3, starting_children: {
+        year: "2012", children_count: 3,
+        is_part_year_claim: "yes",
+        starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
             stop: { day: "05", month: "04", year: "2013" },
@@ -540,6 +581,7 @@ describe ChildBenefitTaxCalculator, type: :model do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: 1,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "14", month: "01", year: "2013" },
@@ -553,6 +595,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "52000",
         year: "2013",
         children_count: 3,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -576,6 +619,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "53000",
         year: "2013",
         children_count: 3,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -599,6 +643,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "61000",
         year: "2013",
         children_count: 1,
+        is_part_year_claim: "yes",
         starting_children: {
           "0" => {
             start: { day: "01", month: "07", year: "2013" },
@@ -615,6 +660,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 3,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -636,6 +682,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "04", day: "06" },
@@ -649,6 +696,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 2,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -666,6 +714,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           year: "2014",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -682,6 +731,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 3,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -703,6 +753,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2015", month: "04", day: "06" },
@@ -716,6 +767,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 2,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -733,6 +785,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           year: "2015",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -749,6 +802,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 3,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -770,6 +824,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: "1",
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { year: "2016", month: "04", day: "06" },
@@ -783,6 +838,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 2,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -800,6 +856,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(
           year: "2016",
           children_count: 1,
+          is_part_year_claim: "yes",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -64,6 +64,27 @@ describe ChildBenefitTaxCalculator, type: :model do
       @calc.valid?
       expect(@calc.errors).to have_key(:tax_year)
     end
+    it "should contain errors if number of children is less than those being part claimed" do
+      @calc = ChildBenefitTaxCalculator.new(
+        year: "2013",
+        children_count: "1",
+        part_year_children_count: "2",
+        is_part_year_claim: "yes",
+        starting_children: {
+          "0" => {
+            start: { year: "2013", month: "01", day: "01" },
+            stop: { year: "2014", month: "01", day: "01" },
+          },
+          "1" => {
+            start: { year: "2013", month: "03", day: "01" },
+            stop: { year: "2014", month: "03", day: "01" },
+          },
+        },
+      )
+      @calc.valid?
+
+      expect(@calc.errors).to have_key(:part_year_children_count)
+    end
     it "should validate dates provided for children" do
       expect(@calc.starting_children.first.errors.has_key?(:start_date)).to eq(true)
 

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -147,6 +147,25 @@ describe ChildBenefitTaxCalculator, type: :model do
         ).has_errors?).to eq(false)
       end
     end
+
+    describe "#is_part_year_claim" do
+      it "should contain errors if tax claim duration is not provided" do
+        calc = ChildBenefitTaxCalculator.new(children_count: "1", year: 2012)
+        calc.valid?
+        expect(calc.errors).to have_key(:is_part_year_claim)
+        expect(calc.errors.size).to eq(1)
+      end
+      it "should not contain errors if tax claim duration is set to no" do
+        calc = ChildBenefitTaxCalculator.new(children_count: "1", year: 2012, is_part_year_claim: "no")
+        calc.valid?
+        expect(calc.errors).to be_empty
+      end
+      it "should not contain errors if tax claim duration is set to yes" do
+        calc = ChildBenefitTaxCalculator.new(children_count: "1", year: 2012, is_part_year_claim: "yes")
+        calc.valid?
+        expect(calc.errors).to be_empty
+      end
+    end
   end
 
   describe "calculating benefits received" do
@@ -789,6 +808,33 @@ describe ChildBenefitTaxCalculator, type: :model do
           },
         )
         expect(calc.benefits_claimed_amount.round(2)).to eq(621.0)
+      end
+
+      it "should set the start date to start of the selected tax year" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2015",
+          children_count: 1,
+          is_part_year_claim: "no"
+        )
+
+        expect(calc.child_benefit_start_date).to eq(Date.parse("06 April 2015"))
+        expect(calc.child_benefit_end_date).to eq(Date.parse("05 April 2016"))
+      end
+
+      it "should set the stop date to end of the selected tax year" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2015",
+          children_count: 1,
+          is_part_year_claim: "yes",
+          starting_children: {
+            "0" => {
+              start: { day: "06", month: "04", year: "2015" },
+              stop: { day: "", month: "", year: "" },
+            },
+          },
+        )
+
+        expect(calc.child_benefit_end_date).to eq(Date.parse("05 April 2016"))
       end
     end
   end

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -24,6 +24,32 @@ describe ChildBenefitTaxCalculator, type: :model do
     expect(calc.adjusted_net_income).to eq(100900)
   end
 
+  describe "#monday_on_or_after" do
+    subject { ChildBenefitTaxCalculator.new }
+
+    it "should return the tomorrow if the date is a Sunday" do
+      sunday = Date.parse("1 January 2012")
+      monday = Date.parse("2 January 2012")
+
+      expect(subject.monday_on_or_after(sunday)).to eq(monday)
+    end
+
+    it "should return today if today is a Monday" do
+      monday = Date.parse("2 January 2012")
+
+      expect(subject.monday_on_or_after(monday)).to eq(monday)
+    end
+
+    it "should return the following Monday for days between Tueday and Saturday" do
+      tuesday = Date.parse("3 January 2012")
+      saturday = Date.parse("7 January 2012")
+      next_monday = Date.parse("9 January 2012")
+
+      expect(subject.monday_on_or_after(tuesday)).to eq(next_monday)
+      expect(subject.monday_on_or_after(saturday)).to eq(next_monday)
+    end
+  end
+
   describe "input validation" do
     before(:each) do
       @calc = ChildBenefitTaxCalculator.new(children_count: "1")

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -53,7 +53,7 @@ describe ChildBenefitTaxCalculator, type: :model do
 
   describe "input validation" do
     before(:each) do
-      @calc = ChildBenefitTaxCalculator.new(children_count: "1", is_part_year_claim: "no")
+      @calc = ChildBenefitTaxCalculator.new(children_count: "1", is_part_year_claim: "yes")
       @calc.valid?
     end
     it "should contain errors for year if none is given" do
@@ -66,6 +66,7 @@ describe ChildBenefitTaxCalculator, type: :model do
     end
     it "should validate dates provided for children" do
       expect(@calc.starting_children.first.errors.has_key?(:start_date)).to eq(true)
+
       @calc.starting_children << StartingChild.new(
         start: { year: "2012", month: "02", day: "01" },
         stop: { year: "2012", month: "01", day: "01" },

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -139,7 +139,6 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1", is_part_year_claim: "yes")
         calc.valid?
         expect(calc.errors).to be_empty
-        #puts calc.starting_children.first.errors.full_messages
         expect(calc.has_errors?).to eq(true)
       end
       it "should be false if the tax year and starting date are valid" do

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -488,10 +488,10 @@ describe ChildBenefitTaxCalculator, type: :model do
           },
         },
       )
-      expect(calc.benefits_claimed_amount.round(2)).to eq(598.90)
-      expect(calc.tax_estimate).to eq(359)
+      expect(calc.benefits_claimed_amount.round(2)).to eq(612.30)
+      expect(calc.tax_estimate).to eq(367)
     end
-    it "should calculate one week for one child observing the 'next Monday' rule." do
+    it "should calculate two weeks for one child observing the 'Monday' rules." do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: 1,
@@ -501,7 +501,7 @@ describe ChildBenefitTaxCalculator, type: :model do
             stop: { day: "21", month: "01", year: "2013" },
           },
         },
-      ).benefits_claimed_amount.round(2)).to eq(20.30)
+      ).benefits_claimed_amount.round(2)).to eq(40.60)
     end
     it "should calculate 3 children already in the household for 2013/2014" do
       calc = ChildBenefitTaxCalculator.new(
@@ -556,7 +556,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         children_count: 1,
         starting_children: {
           "0" => {
-            start: { day: "24", month: "06", year: "2013" },
+            start: { day: "01", month: "07", year: "2013" },
             stop: { day: "", month: "", year: "" },
           },
         },
@@ -651,7 +651,7 @@ describe ChildBenefitTaxCalculator, type: :model do
               stop: { day: "", month: "", year: "" },
             },
          },
-       ).benefits_claimed_amount.round(2)).to eq(2501.2)
+       ).benefits_claimed_amount.round(2)).to eq(2549.3)
       end
 
       it "should give the total amount of benefits received for a full tax year 2015" do
@@ -664,7 +664,7 @@ describe ChildBenefitTaxCalculator, type: :model do
               stop: { year: "2016", month: "04", day: "05" },
             },
           },
-        ).benefits_claimed_amount.round(2)).to eq(1076.4)
+        ).benefits_claimed_amount.round(2)).to eq(1097.1)
       end
 
       it "should give total amount of benefits one child full year one child half a year" do
@@ -681,7 +681,7 @@ describe ChildBenefitTaxCalculator, type: :model do
               stop: { day: "06", month: "11", year: "2016" },
             },
           },
-        ).benefits_claimed_amount.round(2)).to eq(1788.8)
+        ).benefits_claimed_amount.round(2)).to eq(1823.2)
       end
 
       it "should give total amount of benefits for one child for half a year" do
@@ -695,7 +695,7 @@ describe ChildBenefitTaxCalculator, type: :model do
             },
           },
         )
-        expect(calc.benefits_claimed_amount.round(2)).to eq(621.0)
+        expect(calc.benefits_claimed_amount.round(2)).to eq(641.7)
       end
     end
 

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -16,6 +16,7 @@ describe ChildBenefitTaxCalculator, type: :model do
     expect(ChildBenefitTaxCalculator.new(
       year: "2012", children_count: "1",
       is_part_year_claim: "yes",
+      part_year_children_count: "1",
       starting_children: { "0" => { start: { year: "2011", month: "01", day: "01" } } },
     ).can_calculate?).to eq(true)
   end
@@ -100,6 +101,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -116,6 +118,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -132,6 +135,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: "3",
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "01", day: "01" },
@@ -157,7 +161,12 @@ describe ChildBenefitTaxCalculator, type: :model do
         expect(@calc.errors.size).to eq(1)
       end
       it "should be true if any starting children have errors" do
-        calc = ChildBenefitTaxCalculator.new(year: "2012", children_count: "1", is_part_year_claim: "yes")
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2012",
+          children_count: "1",
+          is_part_year_claim: "yes",
+          part_year_children_count: "1"
+        )
         calc.valid?
         expect(calc.errors).to be_empty
         expect(calc.has_errors?).to eq(true)
@@ -167,6 +176,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2012",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2012", month: "01", day: "07" } },
           },
@@ -190,6 +200,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         calc = ChildBenefitTaxCalculator.new(children_count: "1",
             year: 2012,
             is_part_year_claim: "yes",
+            part_year_children_count: "1",
             starting_children: {
               "0" => { start: { year: "2012", month: "01", day: "07" } },
             }
@@ -200,12 +211,38 @@ describe ChildBenefitTaxCalculator, type: :model do
     end
   end
 
+  describe "full year and part year children" do
+    it "should not contain errors if valid part year and full year children" do
+      calc = ChildBenefitTaxCalculator.new(
+        children_count: "3",
+        year: "2016",
+        is_part_year_claim: "yes",
+        part_year_children_count: "2",
+        starting_children: {
+          "0" => {
+            start: { year: "2016", month: "06", day: "13" },
+            stop: { year: "2016", month: "06", day: "19" },
+          },
+          "1" => {
+            start: { year: "2016", month: "06", day: "20" },
+            stop: { year: "2016", month: "06", day: "26" },
+          }
+        }
+      )
+      calc.valid?
+      calc.starting_children.each do |child|
+        expect(child.errors).to be_empty
+      end
+    end
+  end
+
   describe "calculating benefits received" do
     it "should give the total amount of benefits received for a full tax year 2012" do
       expect(ChildBenefitTaxCalculator.new(
         year: "2012",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2011", month: "02", day: "01" },
@@ -219,6 +256,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2013", month: "04", day: "06" },
@@ -232,6 +270,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: "1",
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -245,6 +284,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: "2",
         is_part_year_claim: "yes",
+        part_year_children_count: "2",
         starting_children: {
           "0" => {
             start: { year: "2012", month: "06", day: "01" },
@@ -382,6 +422,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "49999",
           is_part_year_claim: "yes",
           children_count: 1,
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -393,6 +434,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "50100",
           is_part_year_claim: "yes",
           children_count: 1,
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -405,7 +447,9 @@ describe ChildBenefitTaxCalculator, type: :model do
       it "calculates the correct amount owed for % charge of 100" do
         expect(ChildBenefitTaxCalculator.new(
           adjusted_net_income: "60001",
+          children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -418,6 +462,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "59900",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -430,6 +475,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "54000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2011", month: "01", day: "01" } },
           },
@@ -444,6 +490,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "60001",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -456,6 +503,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "59900",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => { start: { year: "2013", month: "01", day: "01" } },
           },
@@ -468,6 +516,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "54000",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2011", month: "01", day: "01" },
@@ -488,6 +537,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "61000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "03", day: "01" },
@@ -504,6 +554,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "61000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2012", month: "05", day: "01" },
@@ -520,6 +571,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "61000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2013", month: "02", day: "01" },
@@ -539,6 +591,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           adjusted_net_income: "61000",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "02", day: "22" },
@@ -559,6 +612,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: 3,
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
@@ -580,6 +634,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         adjusted_net_income: "56000",
         year: "2012", children_count: 3,
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { day: "06", month: "01", year: "2013" },
@@ -603,6 +658,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: 1,
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { day: "14", month: "01", year: "2013" },
@@ -617,6 +673,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: 3,
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -641,6 +698,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: 3,
         is_part_year_claim: "yes",
+        part_year_children_count: "3",
         starting_children: {
           "0" => {
             start: { day: "06", month: "04", year: "2013" },
@@ -665,6 +723,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2013",
         children_count: 1,
         is_part_year_claim: "yes",
+        part_year_children_count: "1",
         starting_children: {
           "0" => {
             start: { day: "01", month: "07", year: "2013" },
@@ -682,6 +741,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: 3,
           is_part_year_claim: "yes",
+          part_year_children_count: "3",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -704,6 +764,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2014", month: "04", day: "06" },
@@ -718,6 +779,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: 2,
           is_part_year_claim: "yes",
+          part_year_children_count: "2",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -736,6 +798,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2014",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2014" },
@@ -753,6 +816,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 3,
           is_part_year_claim: "yes",
+          part_year_children_count: "3",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -775,6 +839,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2015", month: "04", day: "06" },
@@ -789,6 +854,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 2,
           is_part_year_claim: "yes",
+          part_year_children_count: "2",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -807,6 +873,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },
@@ -824,6 +891,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: 3,
           is_part_year_claim: "yes",
+          part_year_children_count: "3",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -846,6 +914,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: "1",
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { year: "2016", month: "04", day: "06" },
@@ -860,6 +929,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: 2,
           is_part_year_claim: "yes",
+          part_year_children_count: "2",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -878,6 +948,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2016",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2016" },
@@ -904,6 +975,7 @@ describe ChildBenefitTaxCalculator, type: :model do
           year: "2015",
           children_count: 1,
           is_part_year_claim: "yes",
+          part_year_children_count: "1",
           starting_children: {
             "0" => {
               start: { day: "06", month: "04", year: "2015" },

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -211,6 +211,18 @@ describe ChildBenefitTaxCalculator, type: :model do
     end
   end
 
+  describe "full year children only" do
+    it "should be able to calculate the child benefit amount" do
+      calc = ChildBenefitTaxCalculator.new(
+        children_count: 1,
+        year: "2015",
+        is_part_year_claim: "no",
+        starting_children: {}
+      )
+      expect(calc.can_calculate?).to eq(true)
+    end
+  end
+
   describe "full year and part year children" do
     it "should not contain errors if valid part year and full year children" do
       calc = ChildBenefitTaxCalculator.new(

--- a/spec/models/starting_child_spec.rb
+++ b/spec/models/starting_child_spec.rb
@@ -45,29 +45,4 @@ describe StartingChild, type: :model do
     )
     expect(child).to be_valid
   end
-
-  describe "adjusted_start_date" do
-    it "should not adjust the start date if start date is a Monday" do
-      child = StartingChild.new(start: { year: "2013", month: "01", day: "07" })
-      expect(child.adjusted_start_date).to eq(Date.parse("07 January 2013"))
-    end
-
-    it "should return the next Monday for the provided start date" do
-      child = StartingChild.new(start: { year: "2012", month: "01", day: "01" })
-      expect(child.adjusted_start_date).to eq(Date.parse("2 January 2012"))
-
-      child = StartingChild.new(start: { year: "2013", month: "05", day: "08" })
-      expect(child.adjusted_start_date).to eq(Date.parse("13 May 2013"))
-
-      child = StartingChild.new(start: { year: "2013", month: "08", day: "13" })
-      expect(child.adjusted_start_date).to eq(Date.parse("19 August 2013"))
-
-      child = StartingChild.new(start: { year: "2013", month: "01", day: "06" })
-      expect(child.adjusted_start_date).to eq(Date.parse("7 January 2013"))
-    end
-
-    it "should not blow up with a nil start date" do
-      expect(StartingChild.new(start: {}).adjusted_start_date).to be_nil
-    end
-  end
 end

--- a/spec/models/starting_child_spec.rb
+++ b/spec/models/starting_child_spec.rb
@@ -47,9 +47,9 @@ describe StartingChild, type: :model do
   end
 
   describe "adjusted_start_date" do
-    it "should return the next Monday if start date is 7th January 2013" do
+    it "should not adjust the start date if start date is a Monday" do
       child = StartingChild.new(start: { year: "2013", month: "01", day: "07" })
-      expect(child.adjusted_start_date).to eq(Date.parse("14 January 2013"))
+      expect(child.adjusted_start_date).to eq(Date.parse("07 January 2013"))
     end
 
     it "should return the next Monday for the provided start date" do
@@ -64,9 +64,6 @@ describe StartingChild, type: :model do
 
       child = StartingChild.new(start: { year: "2013", month: "01", day: "06" })
       expect(child.adjusted_start_date).to eq(Date.parse("7 January 2013"))
-
-      child = StartingChild.new(start: { year: "2013", month: "01", day: "14" })
-      expect(child.adjusted_start_date).to eq(Date.parse("21 January 2013"))
     end
 
     it "should not blow up with a nil start date" do


### PR DESCRIPTION
Trello cards:
https://trello.com/c/dbyKP467/168-child-benefit-tax-calculator-change-stop-date-in-question-2-to-3-years-in-the-past
https://trello.com/c/hThMXpGx/170-child-benefit-tax-calculator-re-order-questions-2-and-3-swap-them-around
https://trello.com/c/NqFHIT6z/169-child-benefit-tax-calculator-change-which-mondays-are-included-in-the-calculation
https://trello.com/c/eXfGf5lL/171-child-benefit-tax-calculator-add-question-part-year-and-complete-logic-for-answering-no
https://trello.com/c/KbE3axrr/172-child-benefit-tax-calculator-part-year-all-children-add-logic-for-answering-yes
https://trello.com/c/HXEm9Bkk/173-child-benefit-tax-calculator-part-year-some-children-add-logic-for-answering-yes

## Factcheck
[Child benefit tax calculator](https://calculators-pr-149.herokuapp.com/child-benefit-tax-calculator/main)

## Expected Changes

[URL on GOV.UK](https://www.gov.uk/child-benefit-tax-calculator/main)
    
* Stop date should display years from 2013
* Change the rules for which Mondays are included in the calculation
* Move the "choose tax year" question to Question 2
* Add a question to ask if any children are only being claimed for part of the tax year
* Add a question to ask for how many children are only being claimed for part of the tax year

### Stop date should display years from 2013

![screen shot 2016-05-31 at 18 30 37](https://cloud.githubusercontent.com/assets/5793815/15684180/d9f23cf8-275d-11e6-8ff5-22cfbd69dfdf.png)

#### Before

![screen shot 2016-05-31 at 18 31 33](https://cloud.githubusercontent.com/assets/5793815/15684217/04dfa126-275e-11e6-823c-8c4346e60133.png)

#### After

![screen shot 2016-06-01 at 11 52 36](https://cloud.githubusercontent.com/assets/5793815/15707214/6376dfd8-27ef-11e6-9c65-406760f56a28.png)

### Change the rules for which Mondays are included in the calculation

#### Before

##### Copy Change
![screen shot 2016-06-16 at 12 16 33](https://cloud.githubusercontent.com/assets/5793815/16114987/31caf45a-33bc-11e6-90b9-b44913ae2ad4.png)

##### Results
One child
Tax year is 2016 - 2017
Start date is 13/06/2016

![screen shot 2016-06-16 at 12 13 49](https://cloud.githubusercontent.com/assets/5793815/16114918/d3246d8c-33bb-11e6-9ded-07392744388d.png)

#### After

##### Copy Changes
![screen shot 2016-06-16 at 12 15 41](https://cloud.githubusercontent.com/assets/5793815/16114966/1592f3c8-33bc-11e6-81cd-7953a698bea6.png)

One child
Tax year is 2016 - 2017
Start date is 13/06/2016

##### Results
![screen shot 2016-06-16 at 12 14 51](https://cloud.githubusercontent.com/assets/5793815/16114936/f36cf294-33bb-11e6-87db-7dbe1ec4efe0.png)

### Move the "choose tax year" question to Question 2

#### Before

![screen shot 2016-07-08 at 14 18 28](https://cloud.githubusercontent.com/assets/5793815/16688647/e0e36448-4516-11e6-9aa4-d5ca40c3a9cb.png)

#### After

![screen shot 2016-07-08 at 14 19 15](https://cloud.githubusercontent.com/assets/5793815/16688663/fa0349ca-4516-11e6-882d-feab3b48045e.png)

### Add a question to ask if any children are only being claimed for part of the tax year

#### Before

![screen shot 2016-07-08 at 14 21 31](https://cloud.githubusercontent.com/assets/5793815/16688733/4cf5b726-4517-11e6-84ce-90b4fb71ce0b.png)

#### After

![screen shot 2016-07-08 at 14 24 17](https://cloud.githubusercontent.com/assets/5793815/16688794/ac7d2152-4517-11e6-874d-8510ef97d7da.png)

### Add a question to ask for how many children are only being claimed for part of the tax year

#### Before

![screen shot 2016-07-08 at 14 21 31](https://cloud.githubusercontent.com/assets/5793815/16688733/4cf5b726-4517-11e6-84ce-90b4fb71ce0b.png)

#### After

![screen shot 2016-07-08 at 14 31 57](https://cloud.githubusercontent.com/assets/5793815/16689015/bee19110-4518-11e6-8d6e-b58ddc0a6d14.png)