### PR TITLE
Fix tax-year labels on mobile

### DIFF
--- a/app/assets/stylesheets/calculators/child_benefit.scss
+++ b/app/assets/stylesheets/calculators/child_benefit.scss
@@ -125,7 +125,6 @@ li {
 
   .tax-year label {
     @include core-16;
-    display: inline;
   }
 
   .steps {


### PR DESCRIPTION
This is the simplest fix that makes the page work.

A proper fix would be to refactor the CSS for this app, which has
some legacy issues, and doesn't play nicely with some of the common
styles from static.

That is a larger piece of work, that we should definitely do in the
future, but for now, make it not broken for users.

| Before | After |
| --- | --- |
| ![child benefit tax calculator gov uk 2](https://cloud.githubusercontent.com/assets/63201/16735940/da370cda-4782-11e6-8d68-a07d1c267eb8.png) | ![child benefit tax calculator gov uk](https://cloud.githubusercontent.com/assets/63201/16735941/da4bd3b8-4782-11e6-9056-edde6358c604.png) |

Screenshots of other viewport widths not included, but were tested and were OK.
