### PR TITLE
Update the content schema

### DIFF
--- a/app/presenters/calculator_content_item.rb
+++ b/app/presenters/calculator_content_item.rb
@@ -22,7 +22,8 @@ class CalculatorContentItem
     {
       title: calculator.title,
       base_path: base_path,
-      format: 'placeholder_calculator',
+      schema_name: 'placeholder_calculator',
+      document_type: 'calculator_document',
       details: {},
       publishing_app: 'calculators',
       rendering_app: 'calculators',


### PR DESCRIPTION
The content schemas were modified in PR: https://github.com/alphagov/govuk-content-schemas/pull/374

The content published by the calculators app has to conform to the updated
schema.