### PR TITLE
Send documents to Rummager directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently the only calculator in this application is the Child benefit tax calcu
 
 This calculator reports how much child benefit tax you are entitled during a tax year.
 
-There is a cut-off date of 7 January 2013. This is the date [High Income Child Benefit Tax Charge](https://www.gov.uk/child-benefit-tax-charge/overview) came in effect.  
+There is a cut-off date of 7 January 2013. This is the date [High Income Child Benefit Tax Charge](https://www.gov.uk/child-benefit-tax-charge/overview) came in effect.
 This means that if the 2012 tax year is selected the calculator will only calculate the child benefit you are entitled to from 7 Jan 2013 to 5 Apr 2013, not for the entire tax year.
 
 
@@ -40,3 +40,16 @@ $ PR=<number-of-pull-request> ./startup_heroku.sh
 ```
 
 This script will create and configure an app on Heroku, push the __current branch__ and open the child-benefit-tax-calculator Calculator in the browser.
+
+## Additional information
+
+### Dependencies
+
+- [panopticon](https://github.com/alphagov/panopticon): this app sends data to panopticon to register URLs.
+- [rummager](https://github.com/alphagov/rummager): this app indexes its pages
+  for search via Rummager.
+
+### Search indexing
+
+- `bundle exec rake rummager:index_all` will send the data to Rummager for
+  indexing in search.

--- a/app/presenters/search_payload.rb
+++ b/app/presenters/search_payload.rb
@@ -1,0 +1,30 @@
+class SearchPayload
+  attr_reader :calculator
+  delegate :slug,
+           :title,
+           :description,
+           :indexable_content,
+           :content_id,
+           to: :calculator
+
+  def initialize(calculator)
+    @calculator = calculator
+  end
+
+  def self.present(calculator)
+    new(calculator).present
+  end
+
+  def present
+    {
+      content_id: content_id,
+      rendering_app: "calculators",
+      publishing_app: "calculators",
+      format: "custom-application",
+      title: title,
+      description: description,
+      indexable_content: indexable_content,
+      link: "/#{slug}",
+    }
+  end
+end

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -1,0 +1,30 @@
+class SearchIndexer
+  attr_reader :calculator
+  delegate :slug, to: :calculator
+
+  def initialize(calculator)
+    @calculator = calculator
+  end
+
+  def self.call(calculator)
+    new(calculator).call
+  end
+
+  def call
+    Services.rummager.add_document(type, document_id, payload)
+  end
+
+private
+
+  def type
+    'edition'
+  end
+
+  def document_id
+    "/#{slug}"
+  end
+
+  def payload
+    SearchPayload.present(calculator)
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/rummager'
 
 module Services
   def self.publishing_api
@@ -6,5 +7,9 @@ module Services
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
+  end
+
+  def self.rummager
+    @rummager_api ||= GdsApi::Rummager.new(Plek.new.find("search"))
   end
 end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,13 @@
+namespace :rummager do
+  desc "Indexes all calculators in Rummager"
+  task index_all: :environment do
+    require 'gds_api/rummager'
+
+    logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+    logger.info "Sending application data to rummager..."
+
+    Calculator.all.each do |calculator|
+      SearchIndexer.call(calculator)
+    end
+  end
+end

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+RSpec.describe SearchIndexer do
+  describe ".call" do
+    it "sends a document to Rummager" do
+      calculator = Calculator.all.first
+      expect(Services.rummager).to receive(:add_document).with(
+        "edition",
+        "/child-benefit-tax-calculator",
+        content_id: "0e1de8f1-9909-4e45-a6a3-bffe95470275",
+        rendering_app: "calculators",
+        publishing_app: "calculators",
+        format: "custom-application",
+        title: "Child Benefit tax calculator",
+        description: "Work out the Child Benefit you've received and your High Income Child Benefit tax charge.",
+        indexable_content: [
+          "Work out the Child Benefit you've received and your High Income Child Benefit tax charge",
+          "Use this tool to work out",
+          "how much Child Benefit you receive in a tax year",
+          "the High Income Child Benefit tax charge you or your partner may have to pay",
+          "You're affected by the tax charge if your income is over £50,000.",
+          "Your partner is responsible for paying the tax charge if their income is more than £50,000 and higher than yours.",
+          "You'll need the dates Child Benefit started and, if applicable, stopped.",
+        ].join(" "),
+        link: "/child-benefit-tax-calculator",
+      )
+      SearchIndexer.call(calculator)
+    end
+  end
+end


### PR DESCRIPTION
Previously this app would send documents to Panopticon in order to have
them added to the search index. This flow is now being simplified so
that all apps send documents to Rummager directly.

This commit adds:
- a presenter to form the payload required by Rummager. The payload now
  includes the following extra attributes: publishing_app, rendering_app
  and content_id.
- an indexer service object to handle the actual sending.
- a rake task wrapping the above so that it can be run on deploy.
