### PR TITLE
Update gds-api-adapters to 36.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ else
 end
 gem 'plek', '~> 1.12.0'
 
-gem 'gds-api-adapters', '~> 30.0.0'
+gem 'gds-api-adapters', '~> 36.4.0'
 gem 'govuk_frontend_toolkit', '~> 4.9.1'
 gem 'govuk-content-schema-test-helpers', '~> 1.4.0'
 gem 'sass-rails', '5.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,17 +64,17 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20160310)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (30.0.0)
+    gds-api-adapters (36.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk-content-schema-test-helpers (1.4.0)
@@ -104,7 +104,9 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.11.2)
@@ -157,10 +159,10 @@ GEM
     raindrops (0.16.0)
     rake (10.5.0)
     request_store (1.3.0)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -257,7 +259,7 @@ DEPENDENCIES
   airbrake (~> 4.3.0)
   capybara (~> 2.6.2)
   ci_reporter_rspec (~> 1.0.0)
-  gds-api-adapters (~> 30.0.0)
+  gds-api-adapters (~> 36.4.0)
   govuk-content-schema-test-helpers (~> 1.4.0)
   govuk-lint (= 0.8.1)
   govuk_frontend_toolkit (~> 4.9.1)
@@ -276,4 +278,4 @@ DEPENDENCIES
   webmock (~> 1.24.2)
 
 BUNDLED WITH
-   1.11.2
+   1.13.1

--- a/app/controllers/child_benefit_tax_controller.rb
+++ b/app/controllers/child_benefit_tax_controller.rb
@@ -30,7 +30,11 @@ class ChildBenefitTaxController < ApplicationController
 protected
 
   def setup_slimmer
-    artefact = content_api.artefact('child-benefit-tax-calculator')
+    artefact = begin
+                 content_api.artefact('child-benefit-tax-calculator')
+               rescue
+                 nil
+               end
     set_slimmer_artefact_headers(artefact)
   end
 end

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,1 @@
+GdsApi.config.always_raise_for_not_found = true


### PR DESCRIPTION
Update to the latest version, particularly as we've updated the
Panopticon adapter to stop handling search-related attributes (see
alphagov/gds-api-adapters#592).

Includes a code change to handle updated exception behaviour.