### PR TITLE
Rename document type to “calculator”

### DIFF
--- a/app/presenters/calculator_content_item.rb
+++ b/app/presenters/calculator_content_item.rb
@@ -23,7 +23,7 @@ class CalculatorContentItem
       title: calculator.title,
       base_path: base_path,
       schema_name: 'placeholder_calculator',
-      document_type: 'calculator_document',
+      document_type: 'calculator',
       details: {},
       publishing_app: 'calculators',
       rendering_app: 'calculators',


### PR DESCRIPTION
We want to start using `document_type` in place of the deprecated `format` as the value of the `govuk:format` meta tag when using `govuk_components` (https://github.com/alphagov/static/pull/841).

In order to not change the current contents of the meta tag for calculators, this commit changes the `document_type` to match the current `format`.

Trello: https://trello.com/c/fTM6aZlU/171-render-breadcrumb-sidebar-meta-tags-from-content-store-in-calculators