### PR TITLE
Bump Slimmer and update code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'unicorn', '~> 5.0.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '~> 9.6.0'
+  gem 'slimmer', '~> 10.0.0'
 end
 gem 'plek', '~> 1.12.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (9.6.0)
+    slimmer (10.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -283,7 +283,7 @@ DEPENDENCIES
   rspec-rails (~> 3.4.0)
   sass-rails (= 5.0.4)
   simplecov-rcov (= 0.2.3)
-  slimmer (~> 9.6.0)
+  slimmer (~> 10.0.0)
   timecop (~> 0.8.0)
   uglifier (~> 2.7, >= 2.7.2)
   unicorn (~> 5.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,4 +11,3 @@
 // styles
 @import "core";
 @import "calculators/child_benefit";
-@import "helpers/govuk-component-helpers";

--- a/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
+++ b/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
@@ -1,7 +1,0 @@
-// GOV.UK components expect to live in a world with a global reset. This CSS
-// might be pushed up to static at some point.
-.govuk-breadcrumbs ol,
-.govuk-related-items ul {
-  padding: 0;
-  margin: 0;
-}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   include Slimmer::Template
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 
   slimmer_template 'wrapper'
 end


### PR DESCRIPTION
Finding Things has been working on migrating related links, part of that work was to replace the breadcrumbs on a number of different frontend applications like:

- calendars
- calculators
- business-support-finder
- frontend
- licence-finder
- smart-answers

That work has already been done, this commit aims to clean up things we
have missed during the migration.

This includes

- upgrading Slimmer to 10.0.0
- deletion of govuk-component-helpers.scss
- rename [Slimmer::SharedTemplates to Slimmer::GovukComponents](https://github.com/alphagov/slimmer/pull/173)

Trello: https://trello.com/c/5Utjs9qw/300-related-links-cleanup