### PR TITLE
Register routes via publishing-api instead of panopticon

### DIFF
--- a/app/models/calculator.rb
+++ b/app/models/calculator.rb
@@ -2,9 +2,13 @@ class Calculator
   ALL = [{
     title: "Child Benefit tax calculator",
     slug: "child-benefit-tax-calculator",
-    paths: [],
     content_id: "0e1de8f1-9909-4e45-a6a3-bffe95470275",
-    prefixes: ["/child-benefit-tax-calculator"],
+
+    # Sending an empty array for `paths` and `prefixes` will make sure we don't
+    # register routes in Panopticon.
+    prefixes: [],
+    paths: [],
+
     need_id: "100266",
     state: "live",
     description: "Work out the Child Benefit you've received and your High Income Child Benefit tax charge.",

--- a/app/presenters/calculator_content_item.rb
+++ b/app/presenters/calculator_content_item.rb
@@ -22,7 +22,7 @@ class CalculatorContentItem
     {
       title: calculator.title,
       base_path: base_path,
-      schema_name: 'placeholder_calculator',
+      schema_name: 'generic',
       document_type: 'calculator',
       details: {},
       publishing_app: 'calculators',
@@ -30,7 +30,7 @@ class CalculatorContentItem
       locale: 'en',
       public_updated_at: Time.now.iso8601,
       routes: [
-        { type: 'exact', path: base_path }
+        { type: 'prefix', path: base_path }
       ]
     }
   end

--- a/spec/presenters/calculator_content_item_spec.rb
+++ b/spec/presenters/calculator_content_item_spec.rb
@@ -7,7 +7,7 @@ describe CalculatorContentItem do
 
       payload = CalculatorContentItem.new(calculator).payload
 
-      expect(payload).to be_valid_against_schema('placeholder')
+      expect(payload).to be_valid_against_schema('generic')
     end
 
     it 'has the correct data' do

--- a/spec/services/calculator_publisher_spec.rb
+++ b/spec/services/calculator_publisher_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe CalculatorPublisher do
   describe '#publish' do
     it 'publishes the content item' do
-      expect(Services.publishing_api).to receive(:put_content).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', be_valid_against_schema('placeholder'))
+      expect(Services.publishing_api).to receive(:put_content).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', be_valid_against_schema('generic'))
       expect(Services.publishing_api).to receive(:publish).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', 'minor')
       calendar = Calculator.all.first
 


### PR DESCRIPTION
This PR makes this application register its routes via the publishing-api instead of content-store.

It's part of the mainstream preparatory work to remove routing from panopticon.

https://trello.com/c/6eOYmUnL/1-register-routes-via-the-publishing-api-for-publisher-formats