### PR TITLE
Fix closing h2 tag

### DIFF
--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -101,7 +101,7 @@
       <% end %>
       <div id="children-template" style="display:none">
         <div class="part-year-children-count">
-          <h2>How many children do you want to claim only a part of the tax year for?<h2>
+          <h2>How many children do you want to claim only a part of the tax year for?</h2>
           <label for="part_year_children_count" class="visuallyhidden">Number of part year children</label>
           <%= select_tag "part_year_children_count", options_for_select((1..10).collect{|n| [n,n]}, @calculator.part_year_children_count) %>
           <%= submit_tag "Update Children", :name => "children", :class => "button update-button" %>


### PR DESCRIPTION
The closing tag for this `<h2>` is missing a `/` which creates two `<h2>`s when the HTML is parsed because it is interpreted as two opening tags (which HTML5 is fine with).