### PR TITLE
Removed redundant attribute

### DIFF
--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -117,7 +117,7 @@
 
       <% if can_haz_results? -%>
       <div class="results">
-        <h2 id="results" tabindex="0">Results</h2>
+        <h2 id="results">Results</h2>
         <%= render "results" %>
       </div><!-- end .inner -->
       <% end -%>


### PR DESCRIPTION
#132 
A redundant attribute led to the results header being in focus, mentioned in the above referenced issue.