### PR TITLE
Child benefit tax calculator is missing pre-tax pension contribution field

### DIFF
--- a/app/models/adjusted_net_income_calculator.rb
+++ b/app/models/adjusted_net_income_calculator.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 class AdjustedNetIncomeCalculator
-  PARAM_KEYS = [:gross_income, :other_income, :pension_contributions_from_pay,
+  PARAM_KEYS = [:gross_income, :other_income, :pension_contributions_before_tax, :pension_contributions_from_pay,
                 :retirement_annuities, :cycle_scheme, :childcare, :pensions, :property,
                 :non_employment_income, :gift_aid_donations, :outgoing_pension_contributions, :is_part_year_claim]
 
@@ -28,7 +28,7 @@ private
   end
 
   def deductions
-    grossed_up(@pension_contributions_from_pay) + grossed_up(@gift_aid_donations) +
+    @pension_contributions_before_tax + grossed_up(@pension_contributions_from_pay) + grossed_up(@gift_aid_donations) +
       @retirement_annuities + @cycle_scheme + @childcare + grossed_up(@outgoing_pension_contributions)
   end
 

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -77,6 +77,8 @@
           <%= money_input "gross_income", @adjusted_net_income_calculator.gross_income, 'aria-describedby' => 'step-4-description' %>
           <%= label_tag "other_income", "Other employment income - for example taxable benefits (like a company car or medical insurance) or bonuses" %>
           <%= money_input "other_income", @adjusted_net_income_calculator.other_income, 'aria-describedby' => 'step-4-description' %>
+          <%= label_tag "pension_contributions_before_tax", "Pension contributions deducted from your pay before tax" %>
+          <%= money_input "pension_contributions_before_tax", @adjusted_net_income_calculator.pension_contributions_before_tax, 'aria-describedby' => 'step-4-description' %>
           <%= label_tag "pension_contributions_from_pay", "Pension contributions deducted from your pay (don't include contributions deducted before tax)" %>
           <%= money_input "pension_contributions_from_pay", @adjusted_net_income_calculator.pension_contributions_from_pay, 'aria-describedby' => 'step-4-description' %>
           <%= label_tag "retirement_annuities", "Retirement annuity contracts" %>


### PR DESCRIPTION
[ I haven't yet added/updated any tests for this until someone else confirms if the field should be there :) ]

Not sure why I didn't notice this with #129, so perhaps I have misunderstood something! But there doesn't appear to be any field on https://www.gov.uk/child-benefit-tax-calculator/main for entering pension contributions made *before* tax. As it says on https://www.gov.uk/guidance/adjusted-net-income, "Take off any tax reliefs that apply like: payments made gross to pension schemes - those that have been made without tax relief".
But both the pension fields in the calculator are for post-tax pension contributions, either from your pay packet ("Pension contributions deducted from your pay (don't include contributions deducted before tax)"), or private contribution ("Pension contributions not paid from your salary (the amount you actually paid, not the grossed-up amount)").