### PR TITLE
Bump slimmer to use Rails' cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'unicorn', '~> 5.0.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '~> 10.0.0'
+  gem 'slimmer', '~> 10.1.1'
 end
 gem 'plek', '~> 1.12.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (10.0.0)
+    slimmer (10.1.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -283,7 +283,7 @@ DEPENDENCIES
   rspec-rails (~> 3.4.0)
   sass-rails (= 5.0.4)
   simplecov-rcov (= 0.2.3)
-  slimmer (~> 10.0.0)
+  slimmer (~> 10.1.1)
   timecop (~> 0.8.0)
   uglifier (~> 2.7, >= 2.7.2)
   unicorn (~> 5.0.0)

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,8 +1,6 @@
 Calculators::Application.configure do
   config.slimmer.logger = Rails.logger
 
-  config.slimmer.use_cache = true if Rails.env.production?
-
   if Rails.env.development?
     config.slimmer.asset_host = ENV["STATIC_DEV"] || "http://static.dev.gov.uk"
   end


### PR DESCRIPTION
This bumps slimmer to make it use the rails cache and send a user agent:

- https://github.com/alphagov/slimmer/pull/184
- https://github.com/alphagov/slimmer/pull/183

It will prevent this app from making many needless requests to `static`.

https://trello.com/c/D9HmkJwI