### PR TITLE
Register document type with Rummager

### DIFF
--- a/app/presenters/search_payload.rb
+++ b/app/presenters/search_payload.rb
@@ -25,6 +25,7 @@ class SearchPayload
       description: description,
       indexable_content: indexable_content,
       link: "/#{slug}",
+      content_store_document_type: "calculator",
     }
   end
 end

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe SearchIndexer do
           "You'll need the dates Child Benefit started and, if applicable, stopped.",
         ].join(" "),
         link: "/child-benefit-tax-calculator",
+        content_store_document_type: "calculator",
       )
       SearchIndexer.call(calculator)
     end


### PR DESCRIPTION
This change will register the document type in Rummager, so that calculator documents can be found by type.

This is useful for [finding mainstream content](https://trello.com/c/5wrs1iHn/432-load-mainstream-links-from-search-for-the-prototype).


### Trello



https://trello.com/c/bRXYo6XY/433-update-mainstream-publishing-apps