### PR TITLE
Remove PRIVATE_FRONTEND_INTERNAL_LINKS constant

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,8 +8,4 @@ module ApplicationHelper
     text << " <span id='step-#{num}-description'>#{description}</span>" if description.present?
     "<h2><span class='steps' id='step-#{num}'><span class='visuallyhidden'>Step #{num}</span></span>#{text}</h2>".html_safe
   end
-
-  def internal_url(path, edition = 1)
-    PRIVATE_FRONTEND_INTERNAL_LINKS ? "#{Plek.current.find('private-frontend')}#{path}?edition=#{edition}" : "#{path}"
-  end
 end

--- a/app/views/child_benefit_tax/_results.html.erb
+++ b/app/views/child_benefit_tax/_results.html.erb
@@ -15,7 +15,7 @@
       <p class="numbers">£0.00</p>
       <p>There is no tax charge if your income is below £50,099.</p>
       <p>Your partner (if you have one) may have to pay the charge if their income is higher than yours.</p>
-      <p>Find out more about the <a href="<%= internal_url "/child-benefit-tax-charge" %>">tax charge</a>.</p>
+      <p>Find out more about the <a href="/child-benefit-tax-charge">tax charge</a>.</p>
     <% else -%>
       <p class="numbers"><%= number_to_currency @calculator.tax_estimate, unit: "£", precision: 2 %></p>
 
@@ -33,13 +33,13 @@
 
       <p>To pay the tax charge you must fill in a Self Assessment tax return each tax year. Follow these steps:</p>
       <ol>
-        <li><a href="<%= internal_url "/register-for-self-assessment" %>">Register for Self Assessment</a> if you don’t already fill in a tax return - you should do this by <%= sa_register_deadline %>.</li>
+        <li><a href="/register-for-self-assessment">Register for Self Assessment</a> if you don’t already fill in a tax return - you should do this by <%= sa_register_deadline %>.</li>
         <li>Fill in the tax return and include the amount of Child Benefit received for the tax year.</li>
         <li>Send the tax return.</li>
         <li>Pay the tax you owe.</li>
       </ol>
 
-      <p>There are <a href="<%= internal_url "/self-assessment-tax-return-deadlines", 9 %>">deadlines</a> for sending the tax return and paying the tax.</p>
+      <p>There are <a href="/self-assessment-tax-return-deadlines">deadlines</a> for sending the tax return and paying the tax.</p>
 
       <div class="application-notice info-notice">
         <p>The person with the highest income pays the tax charge, so use your partner’s income in the calculator if it’s higher than yours.</p>
@@ -48,7 +48,7 @@
       <h3>Your Child Benefit</h3>
       <p>You can choose to:</p>
       <ul>
-        <li><a href="<%= internal_url "/child-benefit-tax-charge/stop-child-benefit" %>">stop getting Child Benefit</a> - you must pay any tax you owe</li>
+        <li><a href="/child-benefit-tax-charge/stop-child-benefit">stop getting Child Benefit</a> - you must pay any tax you owe</li>
         <li>carry on getting Child Benefit - for each tax year you get it you must fill in a tax return and pay any tax you owe</li>
       </ul>
 
@@ -56,11 +56,11 @@
         <p>Your result for the next tax year may be higher because the tax charge will apply to the whole tax year (and not just 7 January to 5 April 2013).</p>
       <% end -%>
 
-      <p>Find out about <a href="<%= internal_url "/child-benefit-tax-charge" %>">stopping or carrying on Child Benefit</a>.</p>
+      <p>Find out about <a href="/child-benefit-tax-charge">stopping or carrying on Child Benefit</a>.</p>
     <% end -%>
   </div>
 <% else %>
   <h3>Tax charge to pay</h3>
   <p>To work out the tax charge, <a href="#adjusted_income">enter your income or your partner's</a> - whoever has the higher.</p>
-  <p>Find out more about the <a href="<%= internal_url "/child-benefit-tax-charge" %>">tax charge</a>.</p>
+  <p>Find out more about the <a href="/child-benefit-tax-charge">tax charge</a>.</p>
 <% end %>

--- a/app/views/child_benefit_tax/landing.html.erb
+++ b/app/views/child_benefit_tax/landing.html.erb
@@ -26,7 +26,7 @@
         <h2 id="before-you-start">Before you start</h2>
         <p>You may be affected by the tax charge if your income is over £50,000.</p>
         <p>Your partner is responsible for paying the tax charge if their income is more than £50,000 and higher than yours.</p>
-        <p>You’ll need the dates Child Benefit started and, if applicable, <a href="<%= internal_url "/child-benefit/eligibility" %>">Child Benefit stopped</a>.</p>
+        <p>You’ll need the dates Child Benefit started and, if applicable, <a href="/child-benefit/eligibility">Child Benefit stopped</a>.</p>
       </div>
     </article>
 

--- a/config/initializers/internal_links.rb
+++ b/config/initializers/internal_links.rb
@@ -1,4 +1,0 @@
-# For testing on preview, define the following constant as true to force links in the content to
-# point at Private Frontend.
-
-PRIVATE_FRONTEND_INTERNAL_LINKS = false

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,21 +1,6 @@
 require "spec_helper"
 
 describe ApplicationHelper, type: :helper do
-  it "appends the private frontend url to internal links when constant is set" do
-    stub_const("PRIVATE_FRONTEND_INTERNAL_LINKS", true)
-    expect(internal_url("/blah")).to eq("http://private-frontend.dev.gov.uk/blah?edition=1")
-  end
-
-  it "appends the private frontend url with an edition number to internal links when constant is set" do
-    stub_const("PRIVATE_FRONTEND_INTERNAL_LINKS", true)
-    expect(internal_url("/blah", 9)).to eq("http://private-frontend.dev.gov.uk/blah?edition=9")
-  end
-
-  it "does not append the private frontend url to internal links when constant is not set" do
-    stub_const("PRIVATE_FRONTEND_INTERNAL_LINKS", false)
-    expect(internal_url("/blah")).to eq("/blah")
-  end
-
   it "generates the html for a step" do
     expect(step(1, "Blah")).to eq("<h2><span class='steps' id='step-1'><span class='visuallyhidden'>Step 1</span></span>Blah</h2>")
   end


### PR DESCRIPTION
This was used during calculator development to help when testing flows.
It’s no longer needed as links in integration should always show the
current version of the linked content in that environment. In addition,
private-frontend is going away soon.