### PR TITLE
Child Benefit Tax Calculator: Refactor/Adjust Start and Stop date

### DIFF
--- a/app/views/child_benefit_tax/_starting_child.html.erb
+++ b/app/views/child_benefit_tax/_starting_child.html.erb
@@ -5,7 +5,7 @@
   <% end %>
   <%= select_date (child ? child.start_date : nil), :prefix => "starting_children[#{index}][start]",
     :prompt => {:day => "Day", :month => "Month", :year => "Year" }, :order => [:day, :month, :year],
-    :start_year => 20.years.ago(Date.today).year, :end_year => 3.years.since(Date.today).year %>
+    :start_year => DateHelper.years_ago(1, "2012-01-01").year, :end_year => DateHelper.years_since(1).year %>
   &nbsp;&nbsp;
 </div>
 <div class="date-selection">
@@ -15,5 +15,5 @@
   <% end %>
   <%= select_date (child ? child.end_date : nil), :prefix => "starting_children[#{index}][stop]",
     :prompt => {:day => "Day", :month => "Month", :year => "Year" }, :order => [:day, :month, :year],
-    :start_year => 3.years.ago(Date.today).year, :end_year => 10.years.since(Date.today).year %>
+    :start_year => DateHelper.years_ago(1, "2012-01-01").year, :end_year => DateHelper.years_since(1).year %>
 </div>

--- a/lib/date_helper.rb
+++ b/lib/date_helper.rb
@@ -1,0 +1,17 @@
+module DateHelper
+  def self.day(date = nil)
+    if date.present?
+      Date.parse(date)
+    else
+      Date.today
+    end
+  end
+
+  def self.years_ago(period = 10, date = nil)
+    period.years.ago(day(date))
+  end
+
+  def self.years_since(period = 10, date = nil)
+    period.years.since(day(date))
+  end
+end

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -266,13 +266,27 @@ feature "Child Benefit Tax Calculator", js: true do
     expect(page).to have_select("starting_children_0_stop_day", selected: "1")
   end
 
-  it "should allow stop date to be three years in the past" do
-    Timecop.freeze('2014-04-04')
+  it "should render start date to be ten years in the past" do
+    allow(DateHelper).to receive(:years_ago).and_return(Date.parse("2010-01-01"))
+    allow(DateHelper).to receive(:years_since).and_return(Date.parse("2012-01-01"))
+
     visit "/child-benefit-tax-calculator"
     click_on "Start now"
     choose "Yes"
 
-    expected_year_list = ("2011".."2024").to_a
+    expected_year_list = ("2010".."2012").to_a
+    expect(page).to have_select("starting_children_0_start_year", options: expected_year_list.unshift("Year"))
+  end
+
+  it "should render stop date containing the specified date range" do
+    allow(DateHelper).to receive(:years_ago).and_return(Date.parse("2012-01-01"))
+    allow(DateHelper).to receive(:years_since).and_return(Date.parse("2014-01-01"))
+
+    visit "/child-benefit-tax-calculator"
+    click_on "Start now"
+
+    choose "Yes"
+    expected_year_list = ("2012".."2014").to_a
     expect(page).to have_select("starting_children_0_stop_year", options: expected_year_list.unshift("Year"))
   end
 

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -173,7 +173,7 @@ feature "Child Benefit Tax Calculator", js: true do
     select "February", from: "starting_children[0][start][month]"
     select "31", from: "starting_children[0][start][day]"
 
-    select "2002", from: "starting_children[1][start][year]"
+    select "2012", from: "starting_children[1][start][year]"
     select "March", from: "starting_children[1][start][month]"
     select "1", from: "starting_children[1][start][day]"
 

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -274,8 +274,8 @@ feature "Child Benefit Tax Calculator", js: true do
     click_on "Start now"
     choose "Yes"
 
-    expected_year_list = ("2010".."2012").to_a
-    expect(page).to have_select("starting_children_0_start_year", options: expected_year_list.unshift("Year"))
+    expected_year_list = ("2010".."2012").to_a.unshift("Year")
+    expect(page).to have_select("starting_children_0_start_year", options: expected_year_list)
   end
 
   it "should render stop date containing the specified date range" do
@@ -286,8 +286,8 @@ feature "Child Benefit Tax Calculator", js: true do
     click_on "Start now"
 
     choose "Yes"
-    expected_year_list = ("2012".."2014").to_a
-    expect(page).to have_select("starting_children_0_stop_year", options: expected_year_list.unshift("Year"))
+    expected_year_list = ("2012".."2014").to_a.unshift("Year")
+    expect(page).to have_select("starting_children_0_stop_year", options: expected_year_list)
   end
 
   it "should show error if no children are present in the selected tax year" do

--- a/spec/lib/date_helper_test.rb
+++ b/spec/lib/date_helper_test.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe DateHelper do
+  describe "day" do
+    it "returns today's date if no date is supplied" do
+      Timecop.freeze("2017-01-01") do
+        expect(DateHelper.day.to_s).to eq("2017-01-01")
+      end
+    end
+
+    it "returns a parsed date if a valid date is supplied" do
+      expect(DateHelper.day("2017-02-01")).to eq(Date.parse("2017-02-01"))
+    end
+
+    it "raises an ArgumentError if a invalid date is supplied" do
+      expect(lambda { DateHelper.day("702-01") }).to raise_error(ArgumentError, "invalid date")
+    end
+  end
+
+  describe "years_ago" do
+    it "returns a date 10 years earlier" do
+      Timecop.freeze("2017-01-01") do
+        expect(DateHelper.years_ago.to_s).to eq("2007-01-01")
+      end
+    end
+
+    it "returns an earlier date based on the period supplied" do
+      Timecop.freeze("2017-01-01") do
+        expect(DateHelper.years_ago(20).to_s).to eq("1997-01-01")
+      end
+    end
+
+    it "returns an earlier date based on the period and date supplied" do
+      expect(DateHelper.years_ago(5, "1990-01-01").to_s).to eq("1985-01-01")
+    end
+  end
+
+  describe "years_since" do
+    it "returns a date 10 years from today" do
+      Timecop.freeze("2017-01-01") do
+        expect(DateHelper.years_since.to_s).to eq("2027-01-01")
+      end
+    end
+
+    it "returns an future date based on the period supplied" do
+      Timecop.freeze("2017-01-01") do
+        expect(DateHelper.years_since(20).to_s).to eq("2037-01-01")
+      end
+    end
+
+    it "returns an future date based on the period and date supplied" do
+      expect(DateHelper.years_since(5, "1990-01-01").to_s).to eq("1995-01-01")
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/Or19oxCx/612-5-child-benefit-tax-calculator)

## Description 
This PR makes changes to how and what the drop down box renders.

It introduces a date helper modules that contains methods that allow
for start and end year to be returned based on the arguments supplied.

This allow for more flexible dates for be derived and presented to the
user and reduce any previous confusion that may have existed.

In the past users were unable to select 2012 because the date range was
omitted as years past on.

## Factcheck

[Preview link](https://calculators-pr-179.herokuapp.com/child-benefit-tax-calculator/main)
[GOVUK](https://gov.uk/child-benefit-tax-calculator/main)

## Expected changes
- Should be able to select 2012 from the start and stop year drop down
- Reduce the range in the start year drop down.
