### PR TITLE
Use separate content items for start page and form

### DIFF
--- a/app/presenters/calculator_content_item.rb
+++ b/app/presenters/calculator_content_item.rb
@@ -18,6 +18,10 @@ class CalculatorContentItem
     'minor'
   end
 
+  def route_type
+    'exact'
+  end
+
   def payload
     {
       title: calculator.title,
@@ -29,7 +33,7 @@ class CalculatorContentItem
       rendering_app: 'calculators',
       locale: 'en',
       routes: [
-        { type: 'exact', path: base_path }
+        { type: route_type, path: base_path }
       ]
     }
   end

--- a/app/presenters/calculator_content_item.rb
+++ b/app/presenters/calculator_content_item.rb
@@ -30,7 +30,7 @@ class CalculatorContentItem
       locale: 'en',
       public_updated_at: Time.now.iso8601,
       routes: [
-        { type: 'prefix', path: base_path }
+        { type: 'exact', path: base_path }
       ]
     }
   end

--- a/app/presenters/calculator_content_item.rb
+++ b/app/presenters/calculator_content_item.rb
@@ -28,7 +28,6 @@ class CalculatorContentItem
       publishing_app: 'calculators',
       rendering_app: 'calculators',
       locale: 'en',
-      public_updated_at: Time.now.iso8601,
       routes: [
         { type: 'exact', path: base_path }
       ]

--- a/app/presenters/calculator_form_content_item.rb
+++ b/app/presenters/calculator_form_content_item.rb
@@ -1,0 +1,12 @@
+# Renders a content-item for the calculator form for the publishing-api.
+class CalculatorFormContentItem < CalculatorContentItem
+  attr_reader :calculator
+
+  def base_path
+    "/#{calculator.slug}/main"
+  end
+
+  def content_id
+    "882aecb2-90c9-49b1-908d-c800bf22da5a"
+  end
+end

--- a/app/presenters/calculator_form_content_item.rb
+++ b/app/presenters/calculator_form_content_item.rb
@@ -6,6 +6,10 @@ class CalculatorFormContentItem < CalculatorContentItem
     "/#{calculator.slug}/main"
   end
 
+  def route_type
+    'prefix'
+  end
+
   def content_id
     "882aecb2-90c9-49b1-908d-c800bf22da5a"
   end

--- a/app/services/calculator_publisher.rb
+++ b/app/services/calculator_publisher.rb
@@ -4,13 +4,23 @@ class CalculatorPublisher
   end
 
   def publish
-    Services.publishing_api.put_content(rendered.content_id, rendered.payload)
-    Services.publishing_api.publish(rendered.content_id, rendered.update_type)
+    rendered.each do |content_item|
+      Services.publishing_api.put_content(content_item.content_id, content_item.payload)
+      Services.publishing_api.publish(content_item.content_id, content_item.update_type)
+    end
   end
 
 private
 
   def rendered
-    @rendered ||= CalculatorContentItem.new(@calculator)
+    @rendered ||= [start_page_content_item, form_content_item]
+  end
+
+  def start_page_content_item
+    CalculatorContentItem.new(@calculator)
+  end
+
+  def form_content_item
+    CalculatorFormContentItem.new(@calculator)
   end
 end

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -4,7 +4,7 @@
 
 <div class="grid-row">
   <article role="article" class="column-two-thirds">
-    <%= form_tag("process_form", method: :get, id: "child_benefit_tax_calculator", class: "calculator-form") do %>
+    <%= form_tag("main/process_form", method: :get, id: "child_benefit_tax_calculator", class: "calculator-form") do %>
       <%# hidden field to store the tax year so it can persist %>
       <input type="hidden" name="year" value="<%= params[:year] %>" />
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Calculators::Application.routes.draw do
   with_options format: false do |routes|
     routes.get "/child-benefit-tax-calculator" => "child_benefit_tax#landing"
     routes.get "/child-benefit-tax-calculator/main" => "child_benefit_tax#main"
-    routes.get "/child-benefit-tax-calculator/process_form" => "child_benefit_tax#process_form"
+    routes.get "/child-benefit-tax-calculator/main/process_form" => "child_benefit_tax#process_form"
     routes.get "/child-benefit-tax-calculator/y(/*responses)" => redirect("/child-benefit-tax-calculator")
   end
 end

--- a/spec/presenters/calculator_content_item_spec.rb
+++ b/spec/presenters/calculator_content_item_spec.rb
@@ -17,6 +17,14 @@ describe CalculatorContentItem do
 
       expect(payload[:title]).to eql('Child Benefit tax calculator')
     end
+
+    it 'uses an exact route' do
+      calculator = Calculator.all.first
+
+      payload = CalculatorContentItem.new(calculator).payload
+
+      expect(payload[:routes].first[:type]).to eql('exact')
+    end
   end
 
   describe '#base_path' do

--- a/spec/presenters/calculator_form_content_item_spec.rb
+++ b/spec/presenters/calculator_form_content_item_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe CalculatorFormContentItem do
+  describe '#payload' do
+    it 'is valid against the schema' do
+      calculator = Calculator.all.first
+
+      payload = CalculatorFormContentItem.new(calculator).payload
+
+      expect(payload).to be_valid_against_schema('generic')
+    end
+
+    it 'has the correct data' do
+      calculator = Calculator.all.first
+
+      payload = CalculatorFormContentItem.new(calculator).payload
+
+      expect(payload[:title]).to eql('Child Benefit tax calculator')
+    end
+  end
+
+  describe '#content_id' do
+    it 'has an overridden content_id' do
+      calculator = Calculator.all.first
+
+      content_id = CalculatorFormContentItem.new(calculator).content_id
+
+      expect(content_id).to eql("882aecb2-90c9-49b1-908d-c800bf22da5a")
+    end
+  end
+
+  describe '#base_path' do
+    it 'has the correct base path' do
+      calculator = Calculator.all.first
+
+      base_path = CalculatorFormContentItem.new(calculator).base_path
+
+      expect(base_path).to eql("/child-benefit-tax-calculator/main")
+    end
+  end
+end

--- a/spec/presenters/calculator_form_content_item_spec.rb
+++ b/spec/presenters/calculator_form_content_item_spec.rb
@@ -17,6 +17,14 @@ describe CalculatorFormContentItem do
 
       expect(payload[:title]).to eql('Child Benefit tax calculator')
     end
+
+    it 'uses a prefix route' do
+      calculator = Calculator.all.first
+
+      payload = CalculatorFormContentItem.new(calculator).payload
+
+      expect(payload[:routes].first[:type]).to eql('prefix')
+    end
   end
 
   describe '#content_id' do

--- a/spec/services/calculator_publisher_spec.rb
+++ b/spec/services/calculator_publisher_spec.rb
@@ -2,11 +2,16 @@ require 'spec_helper'
 
 describe CalculatorPublisher do
   describe '#publish' do
-    it 'publishes the content item' do
+    it 'publishes content items for start page and form' do
+      # Start page
       expect(Services.publishing_api).to receive(:put_content).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', be_valid_against_schema('generic'))
       expect(Services.publishing_api).to receive(:publish).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', 'minor')
-      calendar = Calculator.all.first
 
+      # Form
+      expect(Services.publishing_api).to receive(:put_content).with('882aecb2-90c9-49b1-908d-c800bf22da5a', be_valid_against_schema('generic'))
+      expect(Services.publishing_api).to receive(:publish).with('882aecb2-90c9-49b1-908d-c800bf22da5a', 'minor')
+
+      calendar = Calculator.all.first
       CalculatorPublisher.new(calendar).publish
     end
   end


### PR DESCRIPTION
The start page [will be moving to Publisher/Frontend](https://trello.com/c/rz7jFckZ/390-3-republish-calculators-start-page-as-a-transaction-page-and-remove-hardcoded-version). This is the first step towards that.

* The form will continue to be rendered by calculators and needs its own content item
  * This content item will have none of the tagged taxons/topics/links
  * The content item will not be sent to rummager, users should start from the start page
* Use exact routes rather than a prefix to separate start page and form
* Create a new content item for the form that gets published on deploy
* Omit `public_updated_at` from payload to avoid discrepancies between first_published_at and public_updated_at.

Calculators currently reads from this hardcoded content_item: https://github.com/alphagov/calculators/blame/two-content-items/app/controllers/child_benefit_tax_controller.rb#L35

Splitting content items has no affect on what's currently rendered.

cc @kevindew @tijmenb @carvil 