### PR TITLE
Stop publishing start page

### DIFF
--- a/app/services/calculator_publisher.rb
+++ b/app/services/calculator_publisher.rb
@@ -4,23 +4,13 @@ class CalculatorPublisher
   end
 
   def publish
-    rendered.each do |content_item|
-      Services.publishing_api.put_content(content_item.content_id, content_item.payload)
-      Services.publishing_api.publish(content_item.content_id, content_item.update_type)
-    end
+    Services.publishing_api.put_content(rendered.content_id, rendered.payload)
+    Services.publishing_api.publish(rendered.content_id, rendered.update_type)
   end
 
 private
 
   def rendered
-    @rendered ||= [start_page_content_item, form_content_item]
-  end
-
-  def start_page_content_item
-    CalculatorContentItem.new(@calculator)
-  end
-
-  def form_content_item
-    CalculatorFormContentItem.new(@calculator)
+    @rendered ||= CalculatorFormContentItem.new(@calculator)
   end
 end

--- a/spec/services/calculator_publisher_spec.rb
+++ b/spec/services/calculator_publisher_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe CalculatorPublisher do
   describe '#publish' do
-    it 'publishes content items for start page and form' do
+    it 'publishes content items for form' do
       # Start page
-      expect(Services.publishing_api).to receive(:put_content).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', be_valid_against_schema('generic'))
-      expect(Services.publishing_api).to receive(:publish).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', 'minor')
+      expect(Services.publishing_api).not_to receive(:put_content).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', be_valid_against_schema('generic'))
+      expect(Services.publishing_api).not_to receive(:publish).with('0e1de8f1-9909-4e45-a6a3-bffe95470275', 'minor')
 
       # Form
       expect(Services.publishing_api).to receive(:put_content).with('882aecb2-90c9-49b1-908d-c800bf22da5a', be_valid_against_schema('generic'))


### PR DESCRIPTION
Can't be deployed until:
* [x] #185 deployed
* [x] https://github.com/alphagov/publisher/pull/629 deployed and rake tasks run

After Publisher has claimed the start page (https://github.com/alphagov/publisher/pull/629) this app will no longer be able to publish to that route. This rake task will error which will prevent the app from being deployable.

* Only publish the form
* Code to remove start page and refactor content item logic will follow
in separate PR. WIP: https://github.com/alphagov/calculators/compare/remove-start-page