### PR TITLE
Change rake description due to retiring content-api

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,5 +1,5 @@
 namespace :publishing_api do
-  desc "Send pages to the content-api"
+  desc "Send pages to the Publishing API"
   task publish: [:environment] do
     Calculator.all.each do |calculator|
       CalculatorPublisher.new(calculator).publish


### PR DESCRIPTION
Small PR as a result of retiring the content-api: https://trello.com/c/2MF97xce/154-retire-content-api.