### PR TITLE
Rails 5 Upgrade CNTD: Add Calculators lib to eager load pat

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -68,5 +68,7 @@ module Calculators
     config.action_dispatch.default_headers = {
       'X-Frame-Options' => 'ALLOWALL'
     }
+    
+    config.eager_load_paths << Rails.root.join('lib')
   end
 end


### PR DESCRIPTION
## Description 

With Rails 5, autoloading is now completely disabled if
config.eager_load is set to true. What this implies is, all file paths
outside of app folder are in your config.autoload_paths and not in
config.eager_load_paths (for example, lib/), these files are no longer
load in deployed environments.

In this repo production environment config.eager_load has been set to
true and development to config.eager_load set to false. This is why
development did not flag this problem

This PR fixes this by adding Rails.root.join('lib') to
config.eager_load_paths in application.rb

## Expected changes 
- Calculators Classes and modules defined under lib are now loaded in production.

## Testing 