### PR TITLE
Reposition the breadcrumb inline with elements

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,11 +21,11 @@
 
   <body>
     <div id="wrapper">
+      <% if @education_navigation_ab_test.should_present_new_navigation_view? %>
+        <%= render partial: 'beta_banner/beta_banner' %>
+      <% end %>
+      <%= render partial: 'govuk_component/breadcrumbs', locals: @breadcrumbs %>
       <main role="main" id="content" class="calculator" lang="<%= I18n.locale %>">
-        <% if @education_navigation_ab_test.should_present_new_navigation_view? %>
-          <%= render partial: 'beta_banner/beta_banner' %>
-        <% end %>
-        <%= render partial: 'govuk_component/breadcrumbs', locals: @breadcrumbs %>
         <%= yield %>
       </main>
     </div>


### PR DESCRIPTION
* Following a change to elements, to keep us consistent
* Breadcrumb now sits outside the main element

https://trello.com/c/IsxWIQXQ/105-investigate-work-needed-to-have-breadcrumbs-consistent-with-govuk-elements
