### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ else
 end
 gem 'plek', '~> 1.12.0'
 
-gem 'gds-api-adapters', '~> 46.0'
+gem 'gds-api-adapters', '~> 47.2'
 gem 'govuk_frontend_toolkit', '~> 6.0.3'
 gem 'govuk-content-schema-test-helpers', '~> 1.4.0'
 gem 'govuk_navigation_helpers', '~> 6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.18)
-    gds-api-adapters (46.0.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -315,7 +315,7 @@ DEPENDENCIES
   binding_of_caller (~> 0.7)
   capybara (~> 2.14.3)
   ci_reporter_rspec (~> 1.0.0)
-  gds-api-adapters (~> 46.0)
+  gds-api-adapters (~> 47.2)
   govuk-content-schema-test-helpers (~> 1.4.0)
   govuk-lint (= 0.8.1)
   govuk_ab_testing (~> 2.3)

--- a/app/presenters/calculator_content_item.rb
+++ b/app/presenters/calculator_content_item.rb
@@ -34,7 +34,8 @@ class CalculatorContentItem
       locale: 'en',
       routes: [
         { type: route_type, path: base_path }
-      ]
+      ],
+      update_type: update_type,
     }
   end
 end

--- a/app/services/calculator_publisher.rb
+++ b/app/services/calculator_publisher.rb
@@ -5,7 +5,7 @@ class CalculatorPublisher
 
   def publish
     Services.publishing_api.put_content(rendered.content_id, rendered.payload)
-    Services.publishing_api.publish(rendered.content_id, rendered.update_type)
+    Services.publishing_api.publish(rendered.content_id)
   end
 
 private

--- a/spec/services/calculator_publisher_spec.rb
+++ b/spec/services/calculator_publisher_spec.rb
@@ -4,7 +4,7 @@ describe CalculatorPublisher do
   describe '#publish' do
     it 'publishes content items for form' do
       expect(Services.publishing_api).to receive(:put_content).with('882aecb2-90c9-49b1-908d-c800bf22da5a', be_valid_against_schema('generic'))
-      expect(Services.publishing_api).to receive(:publish).with('882aecb2-90c9-49b1-908d-c800bf22da5a', 'minor')
+      expect(Services.publishing_api).to receive(:publish).with('882aecb2-90c9-49b1-908d-c800bf22da5a')
 
       calendar = Calculator.all.first
       CalculatorPublisher.new(calendar).publish


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)