### PR TITLE
Add current path to beta banner survey

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,4 +3,8 @@ module ApplicationHelper
   def step(num, text)
     "<h2 class=\"step step-#{num}\">#{text}</h2>".html_safe
   end
+
+  def current_path_without_query_string
+    request.original_fullpath.split("?", 2).first
+  end
 end

--- a/app/views/beta_banner/_beta_banner.html.erb
+++ b/app/views/beta_banner/_beta_banner.html.erb
@@ -5,7 +5,7 @@
           message: <<-MESSAGE
       This is a test version of the layout of this page.
       <a id=taxonomy-survey
-         href='https://www.smartsurvey.co.uk/s/betasurvey2017'
+         href='https://www.smartsurvey.co.uk/s/betasurvey2017?c=#{current_path_without_query_string}'
          target='_blank'
          rel='noopener noreferrer'>
         Take the survey to help us improve it

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 
 describe ApplicationHelper, type: :helper do
-  it "generates the html for a step" do
-    expect(step(1, "Blah")).to eq("<h2 class=\"step step-1\">Blah</h2>")
+  describe '#step' do
+    it "generates the html for a step" do
+      expect(helper.step(1, "Blah")).to eq("<h2 class=\"step step-1\">Blah</h2>")
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,4 +6,16 @@ describe ApplicationHelper, type: :helper do
       expect(helper.step(1, "Blah")).to eq("<h2 class=\"step step-1\">Blah</h2>")
     end
   end
+
+  describe '#current_path_without_query_string' do
+    it "returns the path of the current request" do
+      allow(helper).to receive(:request).and_return(ActionDispatch::TestRequest.new("PATH_INFO" => '/foo/bar'))
+      assert_equal '/foo/bar', helper.current_path_without_query_string
+    end
+
+    it "returns the path of the current request stripping off any query string parameters" do
+      allow(helper).to receive(:request).and_return(ActionDispatch::TestRequest.new("PATH_INFO" => '/foo/bar', "QUERY_STRING" => 'ham=jam&spam=gram'))
+      assert_equal '/foo/bar', helper.current_path_without_query_string
+    end
+  end
 end


### PR DESCRIPTION
For: https://trello.com/c/Bo5SQrIm/215-add-page-tracking-custom-dimension-into-education-beta-survey-banner

This lets the survey team know where each response has come from and
allows them to filter by section of the site.
