### PR TITLE
Reinstate missing bin/rails script

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../config/application', __dir__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/script/rails
+++ b/script/rails
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby1.9.1
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
-
-APP_PATH = File.expand_path('../../config/application', __FILE__)
-require File.expand_path('../../config/boot', __FILE__)
-require 'rails/commands'


### PR DESCRIPTION
This was not meant to be deleted in:
https://github.com/alphagov/calculators/pull/180/files#r118538377

The app will not start on Heroku without this.

Also removing a redundant old rails script from Rails 3.