### PR TITLE
Fix local rspec running

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,13 +43,13 @@ group :development, :test do
   gem 'govuk-lint', '0.8.1'
   gem 'pry-byebug'
   gem 'listen', '~> 3.0.5'
+  gem 'rspec-rails', '~> 3.6.0'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 group :test do
   gem 'poltergeist'
-  gem 'rspec-rails', '~> 3.6.0'
   gem 'capybara', '~> 2.14.3'
   gem 'rails-controller-testing', '~> 1.0.2'
   gem 'simplecov-rcov', '0.2.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,5 +341,8 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webmock (~> 1.24.2)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
    1.15.1


### PR DESCRIPTION
A previous commit 94f3c096cea918447609c5b88f46ca935f20188b had moved
the rspec-rails gem into the test group, when it should be in the
development and test group [1].

This meant that when running locally rspec was not correctly set up.

[1] https://github.com/rspec/rspec-rails#installation