### PR TITLE
Correctly fail tests using RSpec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 SimpleCov.start 'rails'
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= 'test'
+ENV["RACK_ENV"] = ENV["RAILS_ENV"] ||= 'test'
 ENV["GOVUK_APP_DOMAIN"] ||= "dev.gov.uk"
 
 require File.expand_path("../../config/environment", __FILE__)


### PR DESCRIPTION
We previously spotted that if we had invalid HTML on one of our pages, the build would fail (correctly) on Jenkins, but not on our local environments. This was fixed in a [previous pull request][1], such that the build would (correctly) fail locally when running `bundle exec rake`. However, running a single test using `bundle exec rspec <file>` would (incorrectly) pass a test with invalid HTML.

This behaviour appears to be related to the `RACK_ENV` environment variable. We use [Slimmer][2] for skinning GOV.UK frontend apps to give them a consistent look. The build failures are because in a test environment, Slimmer will also parse our HTML and check that it's valid. However, to determine if we're in a test environment, Slimmer [checks the `RACK_ENV` variable][3], which is presumably set correctly when running the application, or when running `rake`, but not when running "just" `rspec`.

This change updates the `RACK_ENV` environment variable to match the `RAILS_ENV` variable, which is also manually set in `spec_helper.rb`. Therefore, Slimmer will be run in "strict" mode, and fail when provided with invalid HTML.

[1]: https://github.com/alphagov/calculators/pull/200
[2]: https://github.com/alphagov/slimmer
[3]: https://github.com/alphagov/slimmer/blob/a529f82153edaeeafdf9e8b4af8fec1ed109a559/lib/slimmer/skin.rb#L13