### PR TITLE
Childcare vouchers

### DIFF
--- a/app/models/adjusted_net_income_calculator.rb
+++ b/app/models/adjusted_net_income_calculator.rb
@@ -24,12 +24,12 @@ class AdjustedNetIncomeCalculator
 private
 
   def additions
-    @gross_income + @other_income + @pensions + @property + @non_employment_income
+    @gross_income + @other_income + @pensions + @property + @non_employment_income + @childcare
   end
 
   def deductions
     grossed_up(@pension_contributions_from_pay) + grossed_up(@gift_aid_donations) +
-      @retirement_annuities + @cycle_scheme + @childcare + grossed_up(@outgoing_pension_contributions)
+      @retirement_annuities + @cycle_scheme + grossed_up(@outgoing_pension_contributions)
   end
 
   def grossed_up(amount)

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -85,7 +85,7 @@
           <%= money_input "other_income", @adjusted_net_income_calculator.other_income, 'aria-describedby' => 'step-4-description', class: "form-control" %>
         </div>
         <div class="form-group">
-          <%= label_tag "childcare", "Taxable benefits provided by your employer - for example the value of any medical insurance, workplace nursery places", class: "form-label" %>
+          <%= label_tag "childcare", "Taxable benefits provided by your employer - for example the value of any medical insurance, company car, or anything else included on your P11D", class: "form-label" %>
           <%= money_input "childcare", @adjusted_net_income_calculator.childcare, 'aria-describedby' => 'step-4-description', class: "form-control" %>
         </div>
         <div class="form-group">

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -85,7 +85,7 @@
           <%= money_input "other_income", @adjusted_net_income_calculator.other_income, 'aria-describedby' => 'step-4-description', class: "form-control" %>
         </div>
         <div class="form-group">
-          <%= label_tag "childcare", "Taxable benefits provided by your employer - for example the value of any medical insurance, childcare vouchers (for the whole year but no more than £55 a week) or workplace nursery places", class: "form-label" %>
+          <%= label_tag "childcare", "Taxable benefits provided by your employer - for example the value of any medical insurance, workplace nursery places", class: "form-label" %>
           <%= money_input "childcare", @adjusted_net_income_calculator.childcare, 'aria-describedby' => 'step-4-description', class: "form-control" %>
         </div>
         <div class="form-group">

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -494,7 +494,7 @@ feature "Child Benefit Tax Calculator", js: true do
 
         expect(content).to have_content "Child Benefit received £263.90"
         expect(content).to have_content "Tax charge to pay £263.00"
-        expect(content).to have_content("based on your estimated adjusted net income of £120,325.00")
+        expect(content).to have_content("based on your estimated adjusted net income of £123,325.00")
       end
     end
 
@@ -522,7 +522,7 @@ feature "Child Benefit Tax Calculator", js: true do
       within(shared_component_selector("govspeak")) do
         component_args = JSON.parse(page.text)
         content = component_args.fetch("content")
-        expect(content).to have_content("based on your estimated adjusted net income of £120,325.00")
+        expect(content).to have_content("based on your estimated adjusted net income of £123,325.00")
       end
 
       fill_in "Salary before tax", with: "£50,000"
@@ -533,8 +533,8 @@ feature "Child Benefit Tax Calculator", js: true do
         content = component_args.fetch("content")
 
         expect(content).to have_content "Child Benefit received £263.90"
-        expect(content).to have_content "Tax charge to pay £7.00"
-        expect(content).to have_content("based on your estimated adjusted net income of £50,325.00")
+        expect(content).to have_content "Tax charge to pay £87.00"
+        expect(content).to have_content("based on your estimated adjusted net income of £53,325.00")
       end
     end
   end

--- a/spec/models/adjusted_net_income_calculator_spec.rb
+++ b/spec/models/adjusted_net_income_calculator_spec.rb
@@ -29,7 +29,7 @@ describe AdjustedNetIncomeCalculator, type: :model do
       expect(calc.childcare).to eq(2000)
       expect(calc.outgoing_pension_contributions).to eq(2000)
 
-      expect(calc.calculate_adjusted_net_income).to eq(61625)
+      expect(calc.calculate_adjusted_net_income).to eq(65625)
     end
   end
 end

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -323,7 +323,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: 2,
         is_part_year_claim: "no",
-      ).adjusted_net_income).to eq(66950)
+      ).adjusted_net_income).to eq(69950)
     end
 
     it "should ignore the adjusted_net_income parameter when using the calculation form params" do
@@ -342,7 +342,7 @@ describe ChildBenefitTaxCalculator, type: :model do
         year: "2012",
         children_count: 2,
         is_part_year_claim: "no",
-      ).adjusted_net_income).to eq(66950)
+      ).adjusted_net_income).to eq(69950)
     end
   end
 


### PR DESCRIPTION
Content changes – remove reference to 'childcare vouchers' from the taxable benefits box
Logic changes – change the calculation for taxable benefits from subtraction to addition