### PR TITLE
Stop stripping organisation info from content item

### DIFF
--- a/app/controllers/child_benefit_tax_controller.rb
+++ b/app/controllers/child_benefit_tax_controller.rb
@@ -29,12 +29,6 @@ protected
 
   def fetch_content_item
     @content_item = Services.content_store.content_item("/child-benefit-tax-calculator/main").to_hash
-    # Remove the organisations from the content item - this will prevent the
-    # govuk:analytics:organisations meta tag from being generated until there is
-    # a better way of doing this.
-    if @content_item["links"]
-      @content_item["links"].delete("organisations")
-    end
   end
 
   def setup_navigation_helpers


### PR DESCRIPTION
For: https://trello.com/c/hpS5pFQe/237-investigate-new-navigation-impact-on-surveys

We stripped organisation info from the content item presented to the
view because it would result in the `govuk:analytics:organisations` meta
tag being set and this would be sent to Google Analytics (GA) as a custom
dimension.  We did this because the tag was mostly used by whitehall and
departmental users wouldn't expect to see mainstream content appearing
in their GA reports for their department.

During migration the mainstream formats ported to government-frontend
started sending this info to GA and it didn't cause any problems.  This
means we're happy to stop stripping this data and have all content items
that have organisation info send it to GA.