### PR TITLE
Add current year to calculator

### DIFF
--- a/app/models/child_benefit_rates.rb
+++ b/app/models/child_benefit_rates.rb
@@ -8,6 +8,7 @@ class ChildBenefitRates
     2014 => [20.5, 13.55],
     2015 => [20.7, 13.7],
     2016 => [20.7, 13.7],
+    2017 => [20.7, 13.7],
   }
 
   def initialize(year)

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -15,6 +15,7 @@ class ChildBenefitTaxCalculator
     "2014" => [Date.parse("2014-04-06"), Date.parse("2015-04-05")],
     "2015" => [Date.parse("2015-04-06"), Date.parse("2016-04-05")],
     "2016" => [Date.parse("2016-04-06"), Date.parse("2017-04-05")],
+    "2017" => [Date.parse("2017-04-06"), Date.parse("2018-04-05")],
   }
 
   validate :valid_child_dates


### PR DESCRIPTION
https://trello.com/c/zrlw5CNd/98-asap-was-missed-in-uprating-add-2017-18-to-child-benefit-tax-calculator-2

Adds 2017-2018 tax year to the child benefit tax calculator.