### PR TITLE
Don't index the calculator

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
     <% if @meta_section %>
       <meta name="govuk:section" content="<%= @meta_section %>">
     <% end %>
+    <meta name="robots" content="noindex, nofollow">
   </head>
 
   <body>


### PR DESCRIPTION
This page just renders the calculator page (https://www.gov.uk/child-benefit-tax-calculator/main). This shouldn't be indexed, since people should always visit the page via the start page (https://www.gov.uk/child-benefit-tax-calculator).

Also prevents searches from showing up.

https://trello.com/c/vmMXWtP7