### PR TITLE
Bundle with new ruby version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,7 +402,7 @@ DEPENDENCIES
   webmock (~> 3.4.2)
 
 RUBY VERSION
-   ruby 2.4.4p296
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
We bumped the ruby version last month, but haven't updated the Gemfile.lock.