### PR TITLE
Fix and improve Child Benefit tax calculator

### DIFF
--- a/app/models/child_benefit_rates.rb
+++ b/app/models/child_benefit_rates.rb
@@ -15,8 +15,6 @@ class ChildBenefitRates
   }.freeze
 
   def initialize(year)
-    raise "Invalid tax year" unless RATES.key?(year)
-
     @year = year
   end
 

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -41,8 +41,7 @@ class ChildBenefitTaxCalculator
   end
 
   def total_number_of_mondays(child_benefit_start_date, child_benefit_end_date)
-    monday = [1] # wday of week in 0-6, Monday is 1
-    (child_benefit_start_date..child_benefit_end_date).to_a.select { |date| monday.include?(date.wday) }.count
+    (child_benefit_start_date..child_benefit_end_date).select(&:monday?).count
   end
 
   def nothing_owed?

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -9,7 +9,7 @@ class ChildBenefitTaxCalculator
     :starting_children, :tax_year, :is_part_year_claim, :part_year_children_count
 
   NET_INCOME_THRESHOLD = 50000
-  TAX_COMMENCEMENT_DATE = Date.parse('7 Jan 2013')
+  TAX_COMMENCEMENT_DATE = Date.parse('7 Jan 2013') # special case for 2012-13, only weeks from 7th Jan 2013 are taxable
 
   TAX_YEARS = (2012..2019).each_with_object({}) { |year, hash|
     hash[year.to_s] = [Date.new(year, 4, 6), Date.new(year + 1, 4, 5)]
@@ -29,6 +29,7 @@ class ChildBenefitTaxCalculator
     @is_part_year_claim = params[:is_part_year_claim]
     @tax_year = params[:year].to_i
     @starting_children = process_starting_children(params[:starting_children])
+    @child_benefit_rates = ChildBenefitRates.new(@tax_year)
   end
 
   def self.valid_date_params?(params)
@@ -39,10 +40,9 @@ class ChildBenefitTaxCalculator
     self.class.valid_date_params?(params)
   end
 
-  # Return the date of the Monday in the future that is closest to the date supplied.
-  # If the date supplied is a Monday, do not adjust it.
-  def monday_on_or_after(date)
-    date.monday? ? date : date.next_week(:monday)
+  def total_number_of_mondays(child_benefit_start_date, child_benefit_end_date)
+    monday = [1] # wday of week in 0-6, Monday is 1
+    (child_benefit_start_date..child_benefit_end_date).to_a.select { |date| monday.include?(date.wday) }.count
   end
 
   def nothing_owed?
@@ -84,23 +84,44 @@ class ChildBenefitTaxCalculator
   end
 
   def benefits_claimed_amount
-    all_weeks_children = {}
-    full_year_children = @children_count - @part_year_children_count
-    (child_benefit_start_date...child_benefit_end_date).each_slice(7) do |week|
-      monday = monday_on_or_after(week.first)
-      all_weeks_children[monday] = 0
-      @starting_children.each do |child|
-        all_weeks_children[monday] += 1 if eligible?(child, tax_year, monday)
-      end
-      full_year_children.times do
-        all_weeks_children[monday] += 1
+    no_of_full_year_children = @children_count - @part_year_children_count
+    first_child_calculated = false
+    total_benefit_amount = 0
+
+    if no_of_full_year_children.positive?
+      no_of_weeks = total_number_of_mondays(child_benefit_start_date, child_benefit_end_date)
+      no_of_additional_children = no_of_full_year_children - 1
+      total_benefit_amount = first_child_rate_total(no_of_weeks) + additional_child_rate_total(no_of_weeks, no_of_additional_children)
+      first_child_calculated = true
+    else
+      first_child_calculated = false
+    end
+
+    if @starting_children.count.positive?
+      first_child = 0
+
+      @starting_children.each_with_index do |child, index|
+        start_date = if (child.start_date < child_benefit_start_date) || ((@tax_year == 2012) && (child.start_date < TAX_COMMENCEMENT_DATE))
+                       child_benefit_start_date
+                     else
+                       child.start_date
+                     end
+
+        end_date = if child.end_date.nil? || (child.end_date > child_benefit_end_date)
+                     child_benefit_end_date
+                   else
+                     child.end_date
+                   end
+
+        no_of_weeks = total_number_of_mondays(start_date, end_date)
+        total_benefit_amount = if index.equal?(first_child) && (first_child_calculated == false)
+                                 total_benefit_amount + first_child_rate_total(no_of_weeks)
+                               else
+                                 total_benefit_amount + additional_child_rate_total(no_of_weeks, 1)
+                               end
       end
     end
-    # calculate total for all weeks
-    total = all_weeks_children.values.inject(0) do |sum, n|
-      sum + BigDecimal(weekly_sum_for_children(n).to_s)
-    end
-    total.to_f
+    total_benefit_amount.to_f
   end
 
   def tax_estimate
@@ -127,38 +148,12 @@ private
     end
   end
 
-  def eligible?(child, tax_year, week_start_date)
-    adjusted_start_date = monday_on_or_after(child.start_date)
-
-    eligible_for_tax_year?(child, tax_year) &&
-      days_include_week?(adjusted_start_date, child.benefits_end, week_start_date)
+  def first_child_rate_total(no_of_weeks)
+    @child_benefit_rates.first_child_rate * no_of_weeks
   end
 
-  def eligible_for_tax_year?(child, tax_year)
-    if tax_year == 2012
-      !(Date.parse('1 April 2013')..Date.parse('5 April 2013')).cover?(child.start_date)
-    else
-      !(Date.parse("31 March #{tax_year + 1}")..Date.parse("5 April #{tax_year + 1}")).cover?(child.start_date)
-    end
-  end
-
-  def days_include_week?(start_date, end_date, week_start_date)
-    if start_date.nil?
-      end_date >= week_start_date
-    elsif end_date.nil?
-      start_date <= week_start_date
-    else
-      (start_date..end_date).cover?(week_start_date)
-    end
-  end
-
-  def weekly_sum_for_children(num_children)
-    rate = ChildBenefitRates.new(tax_year)
-    if num_children.positive?
-      rate.first_child_rate + (num_children - 1) * rate.additional_child_rate
-    else
-      0
-    end
+  def additional_child_rate_total(no_of_weeks, no_of_children)
+    @child_benefit_rates.additional_child_rate * no_of_children * no_of_weeks
   end
 
   def calculate_adjusted_net_income(adjusted_net_income)

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -83,10 +83,6 @@ class ChildBenefitTaxCalculator
     TAX_YEARS[@tax_year.to_s]
   end
 
-  def can_estimate?
-    @total_annual_income.positive? && can_calculate?
-  end
-
   def benefits_claimed_amount
     all_weeks_children = {}
     full_year_children = @children_count - @part_year_children_count
@@ -165,29 +161,12 @@ private
     end
   end
 
-  def taxable_weeks
-    if @tax_year == 2012
-      # special case for 2012-13, only weeks from 7th Jan 2013 are taxable
-      benefit_taxable_weeks(Date.parse("2013-01-07"), child_benefit_end_date)
-    else
-      benefit_taxable_weeks(child_benefit_start_date, child_benefit_end_date)
-    end
-  end
-
-  def benefit_taxable_weeks(start_date, end_date)
-    ((end_date - start_date) / 7).floor
-  end
-
   def calculate_adjusted_net_income(adjusted_net_income)
     if @adjusted_net_income_calculator.can_calculate?
       @adjusted_net_income_calculator.calculate_adjusted_net_income
     elsif adjusted_net_income.present?
       adjusted_net_income.gsub(/[£, -]/, '').to_i
     end
-  end
-
-  def parse_child_date(date)
-    Date.new(date[:year].to_i, date[:month].to_i, date[:day].to_i)
   end
 
   def valid_child_dates

--- a/spec/models/child_benefit_rates_spec.rb
+++ b/spec/models/child_benefit_rates_spec.rb
@@ -7,10 +7,6 @@ describe ChildBenefitRates, type: :model do
     it "should intialize instance correctly" do
       expect(ChildBenefitRates.new(2014).year).to eq(2014)
     end
-
-    it "should raise error" do
-      expect { ChildBenefitRates.new(2000) }.to raise_error("Invalid tax year")
-    end
   end
 
   describe "return correct rates for 2012 year passed in" do

--- a/spec/models/child_benefit_tax_calculator_spec.rb
+++ b/spec/models/child_benefit_tax_calculator_spec.rb
@@ -27,32 +27,6 @@ describe ChildBenefitTaxCalculator, type: :model do
     expect(calc.adjusted_net_income).to eq(100900)
   end
 
-  describe "#monday_on_or_after" do
-    subject { ChildBenefitTaxCalculator.new }
-
-    it "should return the tomorrow if the date is a Sunday" do
-      sunday = Date.parse("1 January 2012")
-      monday = Date.parse("2 January 2012")
-
-      expect(subject.monday_on_or_after(sunday)).to eq(monday)
-    end
-
-    it "should return today if today is a Monday" do
-      monday = Date.parse("2 January 2012")
-
-      expect(subject.monday_on_or_after(monday)).to eq(monday)
-    end
-
-    it "should return the following Monday for days between Tueday and Saturday" do
-      tuesday = Date.parse("3 January 2012")
-      saturday = Date.parse("7 January 2012")
-      next_monday = Date.parse("9 January 2012")
-
-      expect(subject.monday_on_or_after(tuesday)).to eq(next_monday)
-      expect(subject.monday_on_or_after(saturday)).to eq(next_monday)
-    end
-  end
-
   describe "input validation" do
     before(:each) do
       @calc = ChildBenefitTaxCalculator.new(children_count: "1", is_part_year_claim: "yes")
@@ -248,52 +222,227 @@ describe ChildBenefitTaxCalculator, type: :model do
     end
   end
 
-  describe "calculating benefits received" do
-    it "should give the total amount of benefits received for a full tax year 2012" do
-      expect(ChildBenefitTaxCalculator.new(
-        year: "2012",
-        children_count: "1",
-        is_part_year_claim: "no"
-      ).benefits_claimed_amount.round(2)).to eq(263.9)
+  calc = ChildBenefitTaxCalculator.new(
+    year: "2015",
+    children_count: 1,
+    is_part_year_claim: "no"
+  )
+
+  describe "calculating the number of weeks/Mondays" do
+    context "for the full tax year 2012/2013" do
+      it "should calculate there are 13 Mondays" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2012",
+          children_count: "1",
+          is_part_year_claim: "no"
+        )
+        start_date = calc.child_benefit_start_date
+        end_date = calc.child_benefit_end_date
+        expect(calc.total_number_of_mondays(start_date, end_date)).to eq(13)
+      end
     end
-    it "should give the total amount of benefits received for a full tax year 2013" do
-      expect(ChildBenefitTaxCalculator.new(
-        year: "2013",
-        children_count: "1",
-        is_part_year_claim: "no"
-      ).benefits_claimed_amount.round(2)).to eq(1055.6)
+    context "for the full tax year 2013/2014" do
+      it "should calculate there are 52 Mondays" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2013",
+          children_count: "1",
+          is_part_year_claim: "no"
+        )
+        start_date = calc.child_benefit_start_date
+        end_date = calc.child_benefit_end_date
+        expect(calc.total_number_of_mondays(start_date, end_date)).to eq(52)
+      end
     end
-    it "should give the total amount of benefits received for a partial tax year" do
-      expect(ChildBenefitTaxCalculator.new(
-        year: "2012",
-        children_count: "1",
-        is_part_year_claim: "yes",
-        part_year_children_count: "1",
-        starting_children: {
-          "0" => {
-            start: { year: "2012", month: "06", day: "01" },
-            stop: { year: "2013", month: "06", day: "01" },
-          },
-        },
-      ).benefits_claimed_amount.round(2)).to eq(263.9)
+    context "for the full tax year 2014/2015" do
+      it "should calculate there are 52 Mondays" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2014",
+          children_count: "1",
+          is_part_year_claim: "no"
+        )
+        start_date = calc.child_benefit_start_date
+        end_date = calc.child_benefit_end_date
+        expect(calc.total_number_of_mondays(start_date, end_date)).to eq(52)
+      end
     end
-    it "should give the total amount of benefits received for a partial tax year with more than one child" do
-      expect(ChildBenefitTaxCalculator.new(
-        year: "2012",
-        children_count: "2",
-        is_part_year_claim: "yes",
-        part_year_children_count: "2",
-        starting_children: {
-          "0" => {
-            start: { year: "2012", month: "06", day: "01" },
-            stop: { year: "2013", month: "06", day: "01" },
+    context "for the full tax year 2015/2016" do
+      it "should calculate there are 53 Mondays" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2015",
+          children_count: "1",
+          is_part_year_claim: "no"
+        )
+        start_date = calc.child_benefit_start_date
+        end_date = calc.child_benefit_end_date
+        expect(calc.total_number_of_mondays(start_date, end_date)).to eq(53)
+      end
+    end
+    context "for the full tax year 2016/2017" do
+      it "should calculate there are 52 Mondays" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2016",
+          children_count: "1",
+          is_part_year_claim: "no"
+        )
+        start_date = calc.child_benefit_start_date
+        end_date = calc.child_benefit_end_date
+        expect(calc.total_number_of_mondays(start_date, end_date)).to eq(52)
+      end
+    end
+    context "for the full tax year 2017/2018" do
+      it "should calculate there are 52 Mondays" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2017",
+          children_count: "1",
+          is_part_year_claim: "no"
+        )
+        start_date = calc.child_benefit_start_date
+        end_date = calc.child_benefit_end_date
+        expect(calc.total_number_of_mondays(start_date, end_date)).to eq(52)
+      end
+    end
+    context "for the full tax year 2018/2019" do
+      it "should calculate there are 52 Mondays" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2018",
+          children_count: "1",
+          is_part_year_claim: "no"
+        )
+        start_date = calc.child_benefit_start_date
+        end_date = calc.child_benefit_end_date
+        expect(calc.total_number_of_mondays(start_date, end_date)).to eq(52)
+      end
+    end
+    context "for the full tax year 2019/2020" do
+      it "should calculate there are 52 Mondays" do
+        calc = ChildBenefitTaxCalculator.new(
+          year: "2019",
+          children_count: "1",
+          is_part_year_claim: "no"
+        )
+        start_date = calc.child_benefit_start_date
+        end_date = calc.child_benefit_end_date
+        expect(calc.total_number_of_mondays(start_date, end_date)).to eq(52)
+      end
+    end
+  end
+
+  describe "calculating child benefits received" do
+    context "for the tax year 2012" do
+      it "should give the total amount of benefits received for a full tax year 2012" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2012",
+          children_count: "1",
+          is_part_year_claim: "no"
+        ).benefits_claimed_amount.round(2)).to eq(263.9)
+      end
+      it "should give the total amount of benefits received for a partial tax year" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2012",
+          children_count: "1",
+          is_part_year_claim: "yes",
+          part_year_children_count: "1",
+          starting_children: {
+            "0" => {
+              start: { year: "2012", month: "06", day: "01" },
+              stop: { year: "2013", month: "06", day: "01" },
+            },
           },
-          "1" => {
-            start: { year: "2012", month: "05", day: "01" },
-            stop: { year: "2013", month: "07", day: "25" },
+        ).benefits_claimed_amount.round(2)).to eq(263.9)
+      end
+      it "should give the total amount of benefits received for a partial tax year with more than one child" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2012",
+          children_count: "2",
+          is_part_year_claim: "yes",
+          part_year_children_count: "2",
+          starting_children: {
+            "0" => {
+              start: { year: "2012", month: "06", day: "01" },
+              stop: { year: "2013", month: "06", day: "01" },
+            },
+            "1" => {
+              start: { year: "2012", month: "05", day: "01" },
+              stop: { year: "2013", month: "07", day: "25" },
+            },
           },
-        },
-      ).benefits_claimed_amount.round(2)).to eq(438.1)
+        ).benefits_claimed_amount.round(2)).to eq(438.1)
+      end
+    end
+    context "for the tax year 2013" do
+      it "should give the total amount of benefits received for a full tax year 2013" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2013",
+          children_count: "1",
+          is_part_year_claim: "no"
+        ).benefits_claimed_amount.round(2)).to eq(1055.6)
+      end
+    end
+    context "for the tax year 2019" do
+      it "should give the total amount received for the full tax year for one child" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2019",
+          children_count: "1",
+          is_part_year_claim: "no"
+        ).benefits_claimed_amount.round(2)).to eq(1076.4)
+      end
+      it "should give the total amount received for the full tax year for more than one child" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2019",
+          children_count: "2",
+          is_part_year_claim: "no"
+        ).benefits_claimed_amount.round(2)).to eq(1788.8)
+      end
+      it "should give the total amount for a partial tax year for one child" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2019",
+          children_count: "1",
+          is_part_year_claim: "yes",
+          part_year_children_count: "1",
+          starting_children: {
+            "0" => {
+              start: { year: "2020", month: "01", day: "06" },
+              stop: { year: "2020", month: "04", day: "05" },
+            },
+          },
+        ).benefits_claimed_amount.round(2)).to eq(269.1)
+      end
+      it "should give the total amount for a partial tax year for more than one child" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2019",
+          children_count: "2",
+          is_part_year_claim: "yes",
+          part_year_children_count: "2",
+          starting_children: {
+            "0" => { # 18 weeks/Mondays
+              start: { year: "2019", month: "12", day: "2" },
+              stop: { year: "2020", month: "04", day: "05" },
+            },
+            "1" => { # 13 weeks/Mondays
+              start: { year: "2020", month: "01", day: "06" },
+              stop: { year: "2020", month: "04", day: "05" },
+            },
+          },
+        ).benefits_claimed_amount.round(2)).to eq(550.7)
+      end
+      it "should give the total amount for three children, two of which are partial tax years" do
+        expect(ChildBenefitTaxCalculator.new(
+          year: "2019",
+          children_count: "3",
+          is_part_year_claim: "yes",
+          part_year_children_count: "2",
+          starting_children: {
+            "0" => { # 18 weeks/Mondays
+              start: { year: "2019", month: "12", day: "2" },
+              stop: { year: "2020", month: "04", day: "05" },
+            },
+            "1" => { # 13 weeks/Mondays
+              start: { year: "2020", month: "01", day: "06" },
+              stop: { year: "2020", month: "04", day: "05" },
+            },
+          },
+        ).benefits_claimed_amount.round(2)).to eq(1501.1)
+      end
     end
   end
 


### PR DESCRIPTION
HMRC calculates the amount of child benefit between two given dates by
the number of Mondays within its range.

The way the calculator currently works out the child benefit within
the `benefits_claimed_amount` method is not easy to follow, and does not
handle a tax year with a rare scenario in that:
- it is a leap year
- it does not have one Monday in the last tax year month (April)

This means that for this current tax year (6 April 2019 to 5 April 2020)
it's calculating a result based on 53 weeks, when it should be 52 weeks.

The `benefits_claimed_amount` method has been refactored to use the
`Date.wday` method to find out how many Mondays are within a given date
range. This removes the previous complexity where it was being calculated
using an array that indexed the number of "weeks", and then looping through
them to count how many Mondays there are. At this point this is where it
can miscalculate by one Monday/week.

Some additional refactoring has also been done on the partial children
(`@starting_children`) calculation, where the start date and end date is
adjusted if they are empty or outside the tax year dates. This ensures
that only the applicable weeks/Mondays are included in the calculation.

Tests for tax year 2019/2020 have been added and current tests for the
benefit claim amount are hopefully clearer to follow for each tax year.

Trello card: https://trello.com/c/AwQ0Uy1D/957-child-benefit-tax-calculator

A rework of https://github.com/alphagov/calculators/pull/591

[Before](https://www.gov.uk/child-benefit-tax-calculator/main?childcare=&children_count=1&cycle_scheme=&gift_aid_donations=&gross_income=&is_part_year_claim=no&non_employment_income=&other_income=&outgoing_pension_contributions=&pension_contributions_from_pay=&pensions=&property=&results=Calculate&retirement_annuities=&year=2019#results)
![Screen Shot 2019-05-08 at 14 27 12](https://user-images.githubusercontent.com/19667619/57378832-7f3cb580-719d-11e9-88a6-d7aa39806143.png)

[After](https://govuk-calculators-pr-596.herokuapp.com/child-benefit-tax-calculator/main?childcare=&children_count=1&cycle_scheme=&gift_aid_donations=&gross_income=&is_part_year_claim=no&non_employment_income=&other_income=&outgoing_pension_contributions=&pension_contributions_from_pay=&pensions=&property=&results=Calculate&retirement_annuities=&year=2019#results)
![Screen Shot 2019-05-08 at 14 28 37](https://user-images.githubusercontent.com/19667619/57378890-97acd000-719d-11e9-9b8a-809bf9914ac9.png)

