### PR TITLE
Change the cookie serializer to :json

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
To avoid issues associated with the :marshal approach to cookies. This
application has already been using the :hybrid approach, so existing
cookies should already be in the :json format.