### PR TITLE
Rescue 403 errors from content store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  rescue_from GdsApi::HTTPForbidden, with: :error_403
+
   include Slimmer::Template
   slimmer_template "core_layout"
 
@@ -8,5 +10,11 @@ class ApplicationController < ActionController::Base
       name: ENV.fetch("BASIC_AUTH_USERNAME"),
       password: ENV.fetch("BASIC_AUTH_PASSWORD"),
     )
+  end
+
+protected
+
+  def error_403
+    render status: :forbidden, plain: "403 forbidden"
   end
 end

--- a/spec/controllers/child_benefit_tax_controller_spec.rb
+++ b/spec/controllers/child_benefit_tax_controller_spec.rb
@@ -43,4 +43,17 @@ describe ChildBenefitTaxController, type: :controller do
       end
     end
   end
+
+  describe "with content store returning a forbidden response" do
+    before(:each) do
+      stub_request(:get, "#{Plek.find('content-store')}/content/child-benefit-tax-calculator/main").
+        to_return(status: 403, headers: {})
+    end
+
+    it "should return 403 status" do
+      get :main, params: { year: "2013" }
+
+      expect(response.status).to eq 403
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/i7t2LA13/168-unauthenticated-user-accessing-a-calculators-page-with-step-by-step-token-is-directed-to-sign-on
Follows on from: [RFC 113: Expanding draft access for unauthenticated users to allow multi-page fact checks](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md)

## What's changed and why?

At the moment calculators is throwing a 500 when it receives
an error code it doesn't recognise from content-store. That means
that users are shown a "Problem has occurred" page.

We need to handle this error properly so that in the case of a
403, the user will be properly routed to signon and asked to login
if there is any form of access limiting on the content item (e.g.
hosted on draft stack, access limited to organisation)

Note that I copied the error handling code from `frontend` as no
error handling already existed in `calculators`.