### PR TITLE
Use `rubocop-govuk` instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 Style/CommentedKeyword:
   Exclude:
     - 'spec/models/child_benefit_tax_calculator_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,10 @@ end
 
 group :development, :test do
   gem 'timecop', '~> 0.9.1'
-  gem 'govuk-lint', '4.3.0'
   gem 'pry-byebug'
   gem 'listen', '~> 3.2.0'
   gem 'rspec-rails', '~> 3.9.0'
+  gem 'rubocop-govuk'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,11 +96,6 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -263,6 +258,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -290,8 +289,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -365,7 +362,6 @@ DEPENDENCIES
   ci_reporter_rspec (~> 1.0.0)
   gds-api-adapters (~> 61.0.0)
   govuk-content-schema-test-helpers (~> 1.6.1)
-  govuk-lint (= 4.3.0)
   govuk_app_config (~> 2.0.1)
   govuk_elements_rails (~> 3.1.3)
   govuk_frontend_toolkit (~> 9.0.0)
@@ -380,6 +376,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-controller-testing (~> 1.0.4)
   rspec-rails (~> 3.9.0)
+  rubocop-govuk
   sass-rails (= 5.0.7)
   simplecov
   slimmer (~> 13.2.0)


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk