### PR TITLE
Fix text size for tax charge to pay

### DIFF
--- a/app/views/child_benefit_tax/_results.html.erb
+++ b/app/views/child_benefit_tax/_results.html.erb
@@ -28,12 +28,12 @@
         font_size: 19
       } %>
       <% if @calculator.adjusted_net_income < 50100 %>
-        <p class="numbers">£0.00</p>
+        <p class="govuk-!-font-size-80 govuk-!-font-weight-bold">£0.00</p>
         <p>There is no tax charge if your income is below £50,099.</p>
         <p>Your partner (if you have one) may have to pay the charge if their income is higher than yours.</p>
         <p>Find out more about the <a href="/child-benefit-tax-charge">tax charge</a>.</p>
       <% else -%>
-        <p class="numbers"><%= number_to_currency @calculator.tax_estimate, unit: "£", precision: 2 %></p>
+        <p class="govuk-!-font-size-80 govuk-!-font-weight-bold"><%= number_to_currency @calculator.tax_estimate, unit: "£", precision: 2 %></p>
 
         <% if @calculator.tax_year == 2012 %>
           <p>The tax charge only applies to the Child Benefit received between 7 January and 5 April 2013


### PR DESCRIPTION
Before:

<img width="785" alt="Screenshot 2019-11-25 at 07 42 06" src="https://user-images.githubusercontent.com/861310/69521992-317c7480-0f58-11ea-995c-1d9c63ab9709.png">

After:

<img width="898" alt="Screenshot 2019-11-25 at 07 43 15" src="https://user-images.githubusercontent.com/861310/69522001-38a38280-0f58-11ea-8f8a-68d8919aad6f.png">
