### PR TITLE
Remove unused frontend dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ gem 'rails', '~> 5.2.4'
 
 gem 'gds-api-adapters', '~> 63.3.0'
 gem 'govuk_app_config', '~> 2.0.2'
-gem 'govuk_elements_rails', '~> 3.1.3'
-gem 'govuk_frontend_toolkit', '~> 9.0.0'
 gem 'govuk_publishing_components', '~> 21.21.3'
 gem 'govuk-content-schema-test-helpers', '~> 1.6.1'
 gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,13 +101,6 @@ GEM
       sentry-raven (>= 2.7.1, < 2.14.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_elements_rails (3.1.3)
-      govuk_frontend_toolkit (>= 6.0.2)
-      rails (>= 4.1.0)
-      sass (>= 3.2.0)
-    govuk_frontend_toolkit (9.0.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
     govuk_publishing_components (21.21.3)
       gds-api-adapters
       govuk_app_config
@@ -362,8 +355,6 @@ DEPENDENCIES
   gds-api-adapters (~> 63.3.0)
   govuk-content-schema-test-helpers (~> 1.6.1)
   govuk_app_config (~> 2.0.2)
-  govuk_elements_rails (~> 3.1.3)
-  govuk_frontend_toolkit (~> 9.0.0)
   govuk_publishing_components (~> 21.21.3)
   govuk_test
   launchy


### PR DESCRIPTION
The need for `govuk_frontend_toolkit` and `govuk_elements_rails` have been removed in #721, but we missed updating Gemfile.