### PR TITLE
Clarify that the results are an estimates

### DIFF
--- a/app/views/child_benefit_tax/_results.html.erb
+++ b/app/views/child_benefit_tax/_results.html.erb
@@ -43,7 +43,15 @@
         <% if tax_year_incomplete? %>
           <p>This is an estimate based on your adjusted net income of <%= number_to_currency @calculator.adjusted_net_income, unit: "£", precision: 2 %>
             - your circumstances may change before the end of the tax year.</p>
+        <% else %>
+          <p>This is an estimate.</p>
         <% end %>
+
+        <p>The calculator includes the most common sources of income and
+          allowable deductions. If you think you have income or deductions that
+          are not on the calculator, phone the
+          <a href="/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees">Income Tax helpline</a>
+          to find out if you have to pay the tax charge.</p>
 
         <%= render "govuk_publishing_components/components/heading", {
           text: "How and when to pay",


### PR DESCRIPTION
This content change was requested by content designers as the calculator doesn't take into account all possible deductions, so can only be an estimate.

[Trello Card](https://trello.com/c/2SWbq43I/1816-1-content-changes-for-results-in-child-benefit-tax-calculator)