### PR TITLE
Add govuk-compatibility-govuktemplate to remove font duplication.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 $govuk-typography-use-rem: false;
+$govuk-compatibility-govuktemplate: true;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';


### PR DESCRIPTION
While implementing some web performance monitoring I noticed that we are downloading both v1 and v2 fonts for pages using this app. I believe this is because we are missing `$govuk-compatibility-govuktemplate: true;`

![calc-waterfall](https://user-images.githubusercontent.com/1223960/81917935-bd00c500-95cd-11ea-8e27-d42d3b509be0.png)

This PR should hopefully stop the v2 fonts and bring the weight down to 120KB instead of 184KB. Full WebPageTest results can be seen [here](https://www.webpagetest.org/result/200514_WZ_65effaddaff4eddb7855c084415895c2/1/details/#waterfall_view_step1)
 