### PR TITLE
Switch asset hostnames

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,11 @@ module Calculators
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = "1.0"
-    config.assets.prefix = "/calculators"
+    config.assets.prefix = "/assets/calculators"
+
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
 
     # Disable Rack::Cache
     config.action_dispatch.rack_cache = nil

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,9 +31,6 @@ Calculators::Application.configure do
   # Generate digests for assets URLs
   config.assets.digest = true
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
-
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,8 +54,6 @@ Calculators::Application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "support_#{Rails.env}"

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,7 +1,3 @@
 Calculators::Application.configure do
   config.slimmer.logger = Rails.logger
-
-  if Rails.env.development?
-    config.slimmer.asset_host = Plek.current.find("static") || "http://static.dev.gov.uk"
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This is marked as a draft until [Puppet](https://github.com/alphagov/govuk-puppet/pull/10360) is merged and deployed.

This removes the configuration in this app that specifies that this app should use the `assets.publishing.service.gov.uk` hostname for serving assets with the expectation that these assets will instead be served off the `www` hostname. This is to implement [RFC 115](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-115-enabling-http2-on-govuk.md). Because of this the path to assets will be changed to be prefixed with `/assets` so all GOV.UK assets are hosted in the same path.

The asset host can still be configured in this app by a `ASSET_HOST` environment variable, this will be used in govuk-docker and publishing-e2e-tests to avoid needing additional nginx configuration.