### PR TITLE
Create test-dependencies.js to replace live static assets

### DIFF
--- a/app/assets/javascripts/test-dependencies.js
+++ b/app/assets/javascripts/test-dependencies.js
@@ -1,0 +1,3 @@
+// This file contains dependencies that are only needed when running in a test
+// environment. In the dev and live environment these are provided by static.
+//= require govuk_publishing_components/dependencies

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title><%= yield :title %> - GOV.UK</title>
     <%= stylesheet_link_tag "application.css" %>
+    <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
     <%= javascript_include_tag "application" %>
     <%= stylesheet_link_tag "print.css", media: "print" %>
     <meta name="description" content="Work out the Child Benefit you've received and your High Income Child Benefit tax charge">

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,7 @@ module Calculators
       application-ie7.css
       application-ie8.css
       print.css
+      test-dependencies.js
     ]
 
     # Version of your assets, change this if you want to expire all your assets


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

The tests for this app were failing after GOV.UK's assets switched from
the assets hostname to www. This was because slimmer was actually
embedding links to production GOV.UK assets which were symlinked to the
latest ones. Once the assets changed path then the tests broke.

Since it is good practice for tests to be isolated I've created a
test-dependencies.js file which loads in the basic slimmer dependencies
from govuk_publishing_components. This has the advantage that this test
suite no longer has external network requirement, but does have the
disadvantage that the JS isn't the same. This trade-off seems reasonable
since there was never anything particularly realistic about the slimmer
test template [1] and it's mostly luck that it matches production.

[1]: https://github.com/alphagov/slimmer/blob/master/lib/slimmer/test_templates/wrapper.html