### PR TITLE
Use individual component JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,7 @@
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/radio
 //= require child-benefit-tax-calculator
-//= require govuk_publishing_components/all_components


### PR DESCRIPTION
Update calculators to import the Javascript for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).

Note: despite recent changes to the suggested sass feature, the suggested sass for calculators remains unchanged.

## Filesize comparison

<img width="436" alt="Screenshot 2020-06-17 at 10 30 17" src="https://user-images.githubusercontent.com/861310/84881726-2d47ae00-b086-11ea-9bff-43e7504e394a.png">

JS before: **471 KB**

<img width="435" alt="Screenshot 2020-06-17 at 10 32 12" src="https://user-images.githubusercontent.com/861310/84881755-3769ac80-b086-11ea-87f1-74111cca7be4.png">

JS after: **216 KB**


Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

