### PR TITLE
Update colours and Govspeak

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-typography-use-rem: false;
 $govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';

--- a/app/views/child_benefit_tax/_results.html.erb
+++ b/app/views/child_benefit_tax/_results.html.erb
@@ -103,4 +103,6 @@
   <% end %>
 <% end %>
 
-<%= render 'govuk_publishing_components/components/govspeak', content: results_html %>
+<%= render 'govuk_publishing_components/components/govspeak', {} do %>
+ <%= sanitize(results_html) %>
+<% end %>


### PR DESCRIPTION
## What
 - Updates the app to use the new colours palette from the GOV.UK Frontend / Design System.
 - Updates the Govspeak component to use a `do` block rather than the `content` attribute to silence a deprecation warning from the GOV.UK Publishing Components gem

## Why
The colours now match the header and footer and the rest of GOV.UK

Passing content to the Govspeak component using the `content` attribute is [soon to be removed](https://github.com/alphagov/govuk_publishing_components/pull/1632).

## Visual differences

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![image](https://user-images.githubusercontent.com/1732331/94430350-a2e60e80-018b-11eb-9e54-6282c3bcfea4.png)

</td><td>

![image](https://user-images.githubusercontent.com/1732331/94430378-b3968480-018b-11eb-9ed6-58084ba68461.png)

</td></tr>

<tr><td>

![image](https://user-images.githubusercontent.com/1732331/94430562-0839ff80-018c-11eb-88c8-1b6df991982f.png)

</td><td>

![image](https://user-images.githubusercontent.com/1732331/94430599-15ef8500-018c-11eb-97d9-868c3ab2e3b9.png)

</td></tr>

<tr><td>

![image](https://user-images.githubusercontent.com/1732331/94430759-53541280-018c-11eb-82bc-0cef1584607f.png)


</td><td>

![image](https://user-images.githubusercontent.com/1732331/94430700-3ddee880-018c-11eb-9fd1-f566582eddbc.png)


</td></tr>

</table>