### PR TITLE
Lint as part of the default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,13 @@
 require File.expand_path("config/application", __dir__)
 
 Calculators::Application.load_tasks
+
+begin
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+rescue LoadError
+  # Rubocop isn't available in all environments
+end
+
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+task default: %i[rubocop spec]


### PR DESCRIPTION
We had expected that all apps were linting with the default rake task
and removed the linting step from the Jenkins library [1]. However it
seems this app was missed.

[1]: https://github.com/alphagov/govuk-jenkinslib/pull/74