### PR TITLE
Don't define tax years as constants

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,7 +37,7 @@ module ApplicationHelper
   end
 
   def q2_radio_options(calculator)
-    ChildBenefitTaxCalculator::TAX_YEARS.keys.map do |year|
+    ChildBenefitTaxCalculator.tax_years.keys.map do |year|
       {
         value: year,
         text: "#{year} to #{year.to_i + 1}",
@@ -73,7 +73,7 @@ module ApplicationHelper
 
   def year_options(selected)
     start_year = ChildBenefitTaxCalculator::START_YEAR - 1
-    end_year = ChildBenefitTaxCalculator::END_YEAR
+    end_year = ChildBenefitTaxCalculator.end_year
 
     years = Array(start_year..end_year).map do |number|
       format_date(number, :year, selected)

--- a/app/helpers/child_benefit_tax_helper.rb
+++ b/app/helpers/child_benefit_tax_helper.rb
@@ -4,7 +4,7 @@ module ChildBenefitTaxHelper
   end
 
   def tax_year_label(year)
-    dates = ChildBenefitTaxCalculator::TAX_YEARS[year.to_s]
+    dates = ChildBenefitTaxCalculator.tax_years[year.to_s]
     "#{dates.first.year} to #{dates.last.year}"
   end
 
@@ -13,12 +13,12 @@ module ChildBenefitTaxHelper
   end
 
   def sa_register_deadline(calculator)
-    end_date = ChildBenefitTaxCalculator::TAX_YEARS[calculator.tax_year.to_s].last
+    end_date = ChildBenefitTaxCalculator.tax_years[calculator.tax_year.to_s].last
     "5 October #{end_date.year}"
   end
 
   def tax_year_incomplete?(calculator)
-    end_date = ChildBenefitTaxCalculator::TAX_YEARS[calculator.tax_year.to_s].last
+    end_date = ChildBenefitTaxCalculator.tax_years[calculator.tax_year.to_s].last
     end_date >= Time.zone.today
   end
 end

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -15,14 +15,10 @@ class ChildBenefitTaxCalculator
   TAX_COMMENCEMENT_DATE = Date.parse("7 Jan 2013") # special case for 2012-13, only weeks from 7th Jan 2013 are taxable
 
   START_YEAR = 2012
-  END_YEAR = 1.year.from_now.year
-  TAX_YEARS = (START_YEAR...END_YEAR).each_with_object({}) { |year, hash|
-    hash[year.to_s] = [Date.new(year, 4, 6), Date.new(year + 1, 4, 5)]
-  }.freeze
 
   validate :valid_child_dates
   validates :is_part_year_claim, presence: { message: "select part year tax claim" }
-  validates :tax_year, inclusion: { in: TAX_YEARS.keys.map(&:to_i), message: "select a tax year" }
+  validates :tax_year, inclusion: { in: (START_YEAR..), message: "select a tax year" }
   validate :valid_number_of_children
   validate :tax_year_contains_at_least_one_child
 
@@ -92,7 +88,7 @@ class ChildBenefitTaxCalculator
   end
 
   def selected_tax_year
-    TAX_YEARS[@tax_year.to_s]
+    ChildBenefitTaxCalculator.tax_years[@tax_year.to_s]
   end
 
   def benefits_claimed_amount
@@ -138,6 +134,16 @@ class ChildBenefitTaxCalculator
 
   def tax_estimate
     (benefits_claimed_amount * (percent_tax_charge / 100.0)).floor
+  end
+
+  def self.end_year
+    1.year.from_now.year
+  end
+
+  def self.tax_years
+    (START_YEAR...end_year).each_with_object({}) { |year, hash|
+      hash[year.to_s] = [Date.new(year, 4, 6), Date.new(year + 1, 4, 5)]
+    }.freeze
   end
 
 private

--- a/app/models/starting_child.rb
+++ b/app/models/starting_child.rb
@@ -16,7 +16,7 @@ class StartingChild
   end
 
   def benefits_end
-    tax_years = ChildBenefitTaxCalculator::TAX_YEARS
+    tax_years = ChildBenefitTaxCalculator.tax_years
     @end_date || tax_years[tax_years.keys.max].last
   end
 


### PR DESCRIPTION
Class-level constants are set before test suites are initialised and therefore cannot be overriden by timecop (as far as I can tell).

https://trello.com/c/zY7Ulj8Y/2016-fix-tests-in-calculators
