### PR TITLE
Update to components

### DIFF
--- a/app/views/child_benefit_tax/_part_tax_year_conditional.html.erb
+++ b/app/views/child_benefit_tax/_part_tax_year_conditional.html.erb
@@ -25,10 +25,13 @@
     margin_bottom: 4,
     font_size: 24
   } %>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>you can find the start date on your Child Benefit award notice</li>
-    <li>the stop date is usually when a child turns 16 or leaves full-time education</li>
-  </ul>
+  <%= render "govuk_publishing_components/components/list", {
+      visible_counters: true,
+      items: [
+          "you can find the start date on your Child Benefit award notice",
+          "the stop date is usually when a child turns 16 or leaves full-time education",
+      ]
+  } %>
 
   <%= render partial: "child_benefit_tax/starting_children", locals: { calculator: calculator } %>
 </div>

--- a/app/views/child_benefit_tax/_results.html.erb
+++ b/app/views/child_benefit_tax/_results.html.erb
@@ -63,12 +63,16 @@
 
         <p>You need to pay a <a href="/child-benefit-tax-charge">tax charge on the Child Benefit</a> you’ve claimed.</p>
         <p>To pay the tax charge you must fill in a Self Assessment tax return each tax year. Follow these steps:</p>
-        <ol>
-          <li><a href="/register-for-self-assessment">Register for Self Assessment</a> if you don’t already fill in a tax return - you should do this by <%= sa_register_deadline(@calculator) %>.</li>
-          <li>Fill in the tax return and include the amount of Child Benefit received for the tax year.</li>
-          <li>Send the tax return.</li>
-          <li>Pay the tax you owe.</li>
-        </ol>
+        <%= render "govuk_publishing_components/components/list", {
+          list_type: "number",
+          visible_counters: true,
+          items: [
+              sanitize("<a href=\"/register-for-self-assessment\">Register for Self Assessment</a> if you don’t already fill in a tax return - you should do this by #{sa_register_deadline(@calculator)}."),
+              "Fill in the tax return and include the amount of Child Benefit received for the tax year.",
+              "Send the tax return.",
+              "Pay the tax you owe.",
+          ]
+        } %>
 
         <p>There are <a href="/self-assessment-tax-return-deadlines">deadlines</a> for sending the tax return and paying the tax.</p>
 
@@ -82,10 +86,13 @@
           font_size: 19
         } %>
         <p>You can choose to:</p>
-        <ul>
-          <li><a href="/child-benefit-tax-charge/stop-child-benefit">stop getting Child Benefit</a> - you must pay any tax you owe</li>
-          <li>carry on getting Child Benefit - for each tax year you get it you must fill in a tax return and pay any tax you owe</li>
-        </ul>
+        <%= render "govuk_publishing_components/components/list", {
+          visible_counters: true,
+          items: [
+              sanitize("<a href=\"/child-benefit-tax-charge/stop-child-benefit\">stop getting Child Benefit</a> - you must pay any tax you owe"),
+              "carry on getting Child Benefit - for each tax year you get it you must fill in a tax return and pay any tax you owe",
+          ]
+        } %>
 
         <% if @calculator.tax_year == 2012 %>
           <p>Your result for the next tax year may be higher because the tax charge will apply to the whole tax year (and not just 7 January to 5 April 2013).</p>

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -136,6 +136,7 @@
     <% end %>
 
     <% if can_haz_results?(@calculator) %>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       <div class="results">
         <%= render "govuk_publishing_components/components/heading", {
           text: "Results",

--- a/app/views/child_benefit_tax/main.html.erb
+++ b/app/views/child_benefit_tax/main.html.erb
@@ -137,7 +137,12 @@
 
     <% if can_haz_results?(@calculator) %>
       <div class="results">
-        <h2 id="results" class="govuk-heading-xl">Results</h2>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Results",
+          id: "results",
+          font_size: "xl",
+          margin_bottom: 8,
+        } %>
         <%= render "results" %>
       </div>
     <% end %>


### PR DESCRIPTION
## What?

Updating UI elements to use list and header [components](https://components.publishing.service.gov.uk/component-guide/) 

## Why?

As part of on-going work to align Frontend apps to gem architecture, improve consistency, a11y and allow future changes to cascade across all apps.

## Visual changes

- Components swap - none
- Horizontal rule added for results section to improve visual flow due padding alignment between questions and results on desktop

![Screenshot 2021-01-26 at 09 40 50](https://user-images.githubusercontent.com/71266765/105829383-373a7380-5fbc-11eb-9c38-6367ba0c93b8.png)

![Screenshot 2021-01-26 at 09 41 54](https://user-images.githubusercontent.com/71266765/105829372-343f8300-5fbc-11eb-992a-57ff80269997.png)

## Anything else?

[Quick link on live to test](https://www.gov.uk/child-benefit-tax-calculator/main?childcare=&children_count=1&cycle_scheme=&gift_aid_donations=%C2%A3100.00&gross_income=%C2%A320%2C000.00&is_part_year_claim=yes&non_employment_income=&other_income=%C2%A310%2C000.00&outgoing_pension_contributions=&part_year_children_count=1&pension_contributions_from_pay=&pensions=%C2%A3100%2C000.00&property=&results=Calculate&retirement_annuities=&starting_children%5B0%5D%5Bstart%5D%5Bday%5D=2&starting_children%5B0%5D%5Bstart%5D%5Bmonth%5D=2&starting_children%5B0%5D%5Bstart%5D%5Byear%5D=2013&starting_children%5B0%5D%5Bstop%5D%5Bday%5D=&starting_children%5B0%5D%5Bstop%5D%5Bmonth%5D=&starting_children%5B0%5D%5Bstop%5D%5Byear%5D=&year=2013#results)