### PR TITLE
Remove redundant Jenkinsfile config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,5 @@
 library("govuk")
 
 node {
-  govuk.buildProject(
-    beforeTest: { sh("yarn install") },
-    brakeman: true,
-    sassLint: false,
-  )
+  govuk.buildProject()
 }


### PR DESCRIPTION
Yarn install now happens automatically, sassLint is no longer a supported option and brakeman runs implicitly.