### PR TITLE
Limit potential tax years to those with defined rates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,7 +72,7 @@ module ApplicationHelper
   end
 
   def year_options(selected)
-    start_year = ChildBenefitTaxCalculator::START_YEAR - 1
+    start_year = ChildBenefitTaxCalculator.start_year - 1
     end_year = ChildBenefitTaxCalculator.end_year
 
     years = Array(start_year..end_year).map do |number|

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -140,7 +140,7 @@ class ChildBenefitTaxCalculator
 
   def self.end_year
     today = Time.zone.today
-    if today.month > 4 || (today.month == 4 && today.day >= 6)
+    if today >= Date.new(today.year, 4, 6)
       [1.year.from_now.year, ChildBenefitRates::RATES.keys.max].min
     else
       [today.year, ChildBenefitRates::RATES.keys.max].min

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -139,7 +139,12 @@ class ChildBenefitTaxCalculator
   end
 
   def self.end_year
-    [1.year.from_now.year, ChildBenefitRates::RATES.keys.max].min
+    today = Time.zone.today
+    if today.month > 4 || (today.month == 4 && today.day >= 6)
+      [1.year.from_now.year, ChildBenefitRates::RATES.keys.max].min
+    else
+      [today.year, ChildBenefitRates::RATES.keys.max].min
+    end
   end
 
   def self.tax_years

--- a/app/models/child_benefit_tax_calculator.rb
+++ b/app/models/child_benefit_tax_calculator.rb
@@ -14,11 +14,9 @@ class ChildBenefitTaxCalculator
   NET_INCOME_THRESHOLD = 50_000
   TAX_COMMENCEMENT_DATE = Date.parse("7 Jan 2013") # special case for 2012-13, only weeks from 7th Jan 2013 are taxable
 
-  START_YEAR = 2012
-
   validate :valid_child_dates
   validates :is_part_year_claim, presence: { message: "select part year tax claim" }
-  validates :tax_year, inclusion: { in: (START_YEAR..), message: "select a tax year" }
+  validates :tax_year, inclusion: { in: ChildBenefitRates::RATES.keys, message: "select a tax year" }
   validate :valid_number_of_children
   validate :tax_year_contains_at_least_one_child
 
@@ -136,12 +134,16 @@ class ChildBenefitTaxCalculator
     (benefits_claimed_amount * (percent_tax_charge / 100.0)).floor
   end
 
+  def self.start_year
+    ChildBenefitRates::RATES.keys.min
+  end
+
   def self.end_year
-    1.year.from_now.year
+    [1.year.from_now.year, ChildBenefitRates::RATES.keys.max].min
   end
 
   def self.tax_years
-    (START_YEAR...end_year).each_with_object({}) { |year, hash|
+    (start_year..end_year).each_with_object({}) { |year, hash|
       hash[year.to_s] = [Date.new(year, 4, 6), Date.new(year + 1, 4, 5)]
     }.freeze
   end

--- a/spec/features/child_benefit_tax_calculator_spec.rb
+++ b/spec/features/child_benefit_tax_calculator_spec.rb
@@ -23,7 +23,7 @@ feature "Child Benefit Tax Calculator", js: true do
     visit "/child-benefit-tax-calculator/main"
 
     within "#tax_year" do
-      (2012..Time.zone.now.year).map.with_index do |year, index|
+      (2012..Time.zone.now.year - 1).map.with_index do |year, index|
         expect(page).to have_css("#year-#{index}[value='#{year}']", visible: false)
       end
     end
@@ -280,7 +280,7 @@ feature "Child Benefit Tax Calculator", js: true do
     visit "/child-benefit-tax-calculator/main"
     choose "Yes", allow_label_click: true
 
-    expected_year_list = ("2011".."2021").to_a.unshift("")
+    expected_year_list = ("2011".."2020").to_a.unshift("")
     expect(page).to have_select("starting_children_0_start_year", options: expected_year_list)
   end
 
@@ -288,7 +288,7 @@ feature "Child Benefit Tax Calculator", js: true do
     visit "/child-benefit-tax-calculator/main"
 
     choose "Yes", allow_label_click: true
-    expected_year_list = ("2011".."2021").to_a.unshift("")
+    expected_year_list = ("2011".."2020").to_a.unshift("")
     expect(page).to have_select("starting_children_0_stop_year", options: expected_year_list)
   end
 
@@ -606,7 +606,7 @@ feature "Child Benefit Tax Calculator", js: true do
       end
 
       it "should show a warning if the tax_year is incomplete" do
-        choose "year-8", allow_label_click: true, visible: false
+        choose "year-7", allow_label_click: true, visible: false
         click_button "Calculate"
 
         expect(page).to have_content("This is an estimate based on your adjusted net income of £55,000.00")

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -246,7 +246,7 @@ describe ApplicationHelper, type: :helper do
       Timecop.freeze("2020-01-01") do
         years = year_options("2011-04-06")
 
-        expect(years.length).to eq(12)
+        expect(years.length).to eq(11)
         expect(years[0]).to eq(
           text: "",
           value: "",
@@ -260,8 +260,8 @@ describe ApplicationHelper, type: :helper do
 
         expect(years[-1]).to eq(
           selected: false,
-          text: 2021,
-          value: 2021,
+          text: 2020,
+          value: 2020,
         )
 
         years.each_with_index do |option, i|


### PR DESCRIPTION
Limit potential tax years to those with defined rates

A situation can occur where the option for a particular tax year is displayed even before the rates have been defined for it. It should be limited to within this range. (This likely occurs in a new year, because we decide the years to show based on the current calendar year, not the current tax year, but rates are based on tax years).

This was exposed by #1023, which altered the validation — but it is likely that the radio option for a tax year was incorrectly displayed even before that.

https://trello.com/c/pqJGso5N/2341-fix-exceptions-in-calculators